### PR TITLE
feat:  78 먹팟 글 상제 조회 API 응답 추가

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotDetailResponse.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotDetailResponse.kt
@@ -28,6 +28,7 @@ data class MuckpotDetailResponse(
     val y: Double,
     val locationDetail: String? = null,
     val views: Int,
+    val userAge: Int?,
     var participants: List<ParticipantReadResponse>
 ) {
     init {
@@ -59,7 +60,8 @@ data class MuckpotDetailResponse(
             board: Board,
             participants: List<ParticipantReadResponse>,
             prevId: Long? = null,
-            nextId: Long? = null
+            nextId: Long? = null,
+            userAge: Int? = null
         ): MuckpotDetailResponse {
             val response = MuckpotDetailResponse(
                 boardId = board.id ?: 0,
@@ -81,6 +83,7 @@ data class MuckpotDetailResponse(
                 y = board.getY(),
                 locationDetail = board.locationDetail,
                 views = board.views,
+                userAge = userAge,
                 participants = participants
             )
             if (board.isNotAgeLimit()) {

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
@@ -59,11 +59,14 @@ class BoardService(
             if (board.user.id != loginUserInfo?.userId) {
                 board.visit()
             }
+            val userAge: Int? = loginUserInfo?.let { userRepository.findByIdOrNull(it.userId)?.getAge() }
+
             return MuckpotDetailResponse.of(
                 board = board,
                 participants = participantQuerydslRepository.findByBoardIds(listOf(boardId)),
                 prevId = boardQuerydslRepository.findPrevId(boardId),
-                nextId = boardQuerydslRepository.findNextId(boardId)
+                nextId = boardQuerydslRepository.findNextId(boardId),
+                userAge = userAge
             ).apply {
                 sortParticipantsByLoginUser(loginUserInfo)
             }


### PR DESCRIPTION
## 개요
- close #78 

## 작업사항
- 먹팟 글 상제 조회 API 응답 추가 요청 작업
- userAge 값 추가
- 로그인 유저 = 나이 값 계산 후 반환
- 비로그인 유저=  null 반환

## 변경로직
- 내용을 적어주세요.