### PR TITLE
refactor: cookie 발급시 도메인 지정

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/utils/CookieUtil.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/utils/CookieUtil.kt
@@ -13,6 +13,8 @@ import javax.servlet.http.HttpServletResponse
  * Cookie 접근 위한 공통 클래스
  */
 object CookieUtil {
+    private const val COOKIE_DOMAIN = ".mukpat.com"
+
     private val currentRequest: HttpServletRequest
         get() = (RequestContextHolder.currentRequestAttributes() as ServletRequestAttributes).request
     private val currentResponse: HttpServletResponse
@@ -34,12 +36,18 @@ object CookieUtil {
      * 현재 응답에 HttpOnly=true 쿠키 추가.
      */
     fun addHttpOnlyCookie(name: String, value: String, expiredSeconds: Int) {
-        currentResponse.addCookie(
-            Cookie(name, value).apply {
-                path = "/"
-                isHttpOnly = true
-                maxAge = expiredSeconds
+        val cookie = Cookie(name, value).apply {
+            path = "/"
+            isHttpOnly = true
+            maxAge = expiredSeconds
+            domain = COOKIE_DOMAIN
+        }
+        // TODO 서버가 분리되면 해당 로직은 제거, (로컬에서 접근을 위한 설정)
+        currentRequest.serverName?.let { hostName ->
+            if (hostName == "localhost") {
+                cookie.domain = "localhost"
             }
-        )
+        }
+        currentResponse.addCookie(cookie)
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/config/TomcatConfig.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/config/TomcatConfig.kt
@@ -1,0 +1,15 @@
+package com.yapp.muckpot.config
+
+import org.apache.tomcat.util.http.LegacyCookieProcessor
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory
+import org.springframework.boot.web.server.WebServerFactoryCustomizer
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class TomcatConfig : WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
+    override fun customize(factory: TomcatServletWebServerFactory) {
+        factory.addContextCustomizers({ context ->
+            context.cookieProcessor = LegacyCookieProcessor()
+        })
+    }
+}


### PR DESCRIPTION
## 개요
- close #87 

## 작업사항
- 쿠키 발급시 도메인 지정.
- 로컬호스트에서 접근 할 수 있도록 허용

## 기타
- 도메인이 제대로 발급되는지는 테스트를 못했습니다..
- 로컬에서 `.localhost` 발급 테스트 진행했는데 `An invalid domain ... was specified for this cookie`  예외가 발생해서 TomcatConfig를 추가했습니다.
  - [Ref](https://danawalab.github.io/common/2020/02/11/Common-Tomcat-cookieProcessor.html)
- 설정 추가하니 쿠키 발급은 되는데.. 도메인에 `.localhost` 가 아닌, `localhost`로 발급되었습니다..
  - 원인은 못찾았습니다..
- 우선 배포 후, 확인을 해봐야할 것 같아요..!
