### PR TITLE
fix: 87 로컬 접근 시 쿠키 발급 로직 변경

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/utils/CookieUtil.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/utils/CookieUtil.kt
@@ -44,7 +44,7 @@ object CookieUtil {
         }
         // TODO 서버가 분리되면 해당 로직은 제거, (로컬에서 접근을 위한 설정)
         currentRequest.getHeader("Origin")?.let { originName ->
-            if (originName == "http://localhost:3000") {
+            if (originName.startsWith("http://localhost:")) {
                 cookie.domain = "localhost"
             }
         }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/utils/CookieUtil.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/utils/CookieUtil.kt
@@ -43,8 +43,8 @@ object CookieUtil {
             domain = COOKIE_DOMAIN
         }
         // TODO 서버가 분리되면 해당 로직은 제거, (로컬에서 접근을 위한 설정)
-        currentRequest.serverName?.let { hostName ->
-            if (hostName == "localhost") {
+        currentRequest.getHeader("Origin")?.let { originName ->
+            if (originName == "http://localhost:3000") {
                 cookie.domain = "localhost"
             }
         }


### PR DESCRIPTION
## 개요
- close #87 

## 작업사항
- Host 헤더로는 localhost를 구분할 수 없음.
- Origin 으로 로컬요청 확인 후, `domain: localhost` 쿠키 발급

## 기타
- 해당 로직은 v1.0 배포이전 분리해야할 것 같습니다..!