### PR TITLE
feat: 100 먹팟 글 삭제시 메일 전송

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
@@ -90,7 +90,7 @@ class BoardService(
                 request.createBoardUpdateMailBody(board)
             )
             request.updateBoard(board)
-            participantService.sendEmailToParticipants(
+            participantService.sendEmailToParticipantsWithoutWriter(
                 board = board,
                 mailTitle = mailTitle,
                 mailBody = mailBody
@@ -121,7 +121,7 @@ class BoardService(
                 throw MuckPotException(BoardErrorCode.BOARD_UNAUTHORIZED)
             }
             // DELETE 이전에 수행되어야 함.
-            participantService.sendEmailToParticipants(
+            participantService.sendEmailToParticipantsWithoutWriter(
                 board = board,
                 mailTitle = EmailTemplate.BOARD_DELETE_EMAIL.formatSubject(board.title),
                 mailBody = EmailTemplate.BOARD_DELETE_EMAIL.formatBody(board.title)

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
@@ -18,7 +18,6 @@ import com.yapp.muckpot.domains.user.controller.dto.UserResponse
 import com.yapp.muckpot.domains.user.enums.MuckPotStatus
 import com.yapp.muckpot.domains.user.exception.UserErrorCode
 import com.yapp.muckpot.domains.user.repository.MuckPotUserRepository
-import com.yapp.muckpot.email.EmailService
 import com.yapp.muckpot.email.EmailTemplate
 import com.yapp.muckpot.exception.MuckPotException
 import org.springframework.data.repository.findByIdOrNull
@@ -32,7 +31,7 @@ class BoardService(
     private val boardQuerydslRepository: BoardQuerydslRepository,
     private val participantRepository: ParticipantRepository,
     private val participantQuerydslRepository: ParticipantQuerydslRepository,
-    private val emailService: EmailService
+    private val participantService: ParticipantService
 ) {
     @Transactional
     fun saveBoard(userId: Long, request: MuckpotCreateRequest): Long? {
@@ -91,16 +90,11 @@ class BoardService(
                 request.createBoardUpdateMailBody(board)
             )
             request.updateBoard(board)
-            // TODO MQ 적용
-            participantQuerydslRepository.findParticipantEmails(board).forEach { email ->
-                if (board.user.email != email) {
-                    emailService.sendMail(
-                        subject = mailTitle,
-                        body = mailBody,
-                        to = email
-                    )
-                }
-            }
+            participantService.sendEmailToParticipants(
+                board = board,
+                mailTitle = mailTitle,
+                mailBody = mailBody
+            )
         } ?: run {
             throw MuckPotException(BoardErrorCode.BOARD_NOT_FOUND)
         }
@@ -126,6 +120,12 @@ class BoardService(
             if (board.isNotMyBoard(userId)) {
                 throw MuckPotException(BoardErrorCode.BOARD_UNAUTHORIZED)
             }
+            // DELETE 이전에 수행되어야 함.
+            participantService.sendEmailToParticipants(
+                board = board,
+                mailTitle = EmailTemplate.BOARD_DELETE_EMAIL.formatSubject(board.title),
+                mailBody = EmailTemplate.BOARD_DELETE_EMAIL.formatBody(board.title)
+            )
             participantRepository.deleteByBoard(board)
             boardRepository.delete(board)
         } ?: run {

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/ParticipantService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/ParticipantService.kt
@@ -12,7 +12,7 @@ class ParticipantService(
     private val emailService: EmailService
 ) {
     @Transactional
-    fun sendEmailToParticipants(board: Board, mailTitle: String, mailBody: String) {
+    fun sendEmailToParticipantsWithoutWriter(board: Board, mailTitle: String, mailBody: String) {
         // TODO MQ 적용
         participantQuerydslRepository.findParticipantEmails(board).forEach { email ->
             if (board.user.email != email) {

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/ParticipantService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/ParticipantService.kt
@@ -1,0 +1,27 @@
+package com.yapp.muckpot.domains.board.service
+
+import com.yapp.muckpot.domains.board.entity.Board
+import com.yapp.muckpot.domains.board.repository.ParticipantQuerydslRepository
+import com.yapp.muckpot.email.EmailService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ParticipantService(
+    private val participantQuerydslRepository: ParticipantQuerydslRepository,
+    private val emailService: EmailService
+) {
+    @Transactional
+    fun sendEmailToParticipants(board: Board, mailTitle: String, mailBody: String) {
+        // TODO MQ 적용
+        participantQuerydslRepository.findParticipantEmails(board).forEach { email ->
+            if (board.user.email != email) {
+                emailService.sendMail(
+                    subject = mailTitle,
+                    body = mailBody,
+                    to = email
+                )
+            }
+        }
+    }
+}

--- a/muckpot-infra/src/main/kotlin/com/yapp/muckpot/email/EmailTemplate.kt
+++ b/muckpot-infra/src/main/kotlin/com/yapp/muckpot/email/EmailTemplate.kt
@@ -27,6 +27,18 @@ enum class EmailTemplate(
                 "  %s" +
                 "  <br>\n"
         )
+    ),
+
+    // 먹팟 기존 글 제목, 변경 내용
+    BOARD_DELETE_EMAIL(
+        "신청하신 \"%s\"을 작성자가 삭제했습니다.",
+        MAIL_BASIC_FORMAT.format(
+            "  <br>\n" +
+                "  <br>\n" +
+                "  <span style=\"font-size:18px;\">신청하신 \"%s\"을 작성자가 삭제했습니다. </span>\n" +
+                "  <br>\n" +
+                "  <br>\n"
+        )
     );
 
     fun formatSubject(vararg args: Any): String {

--- a/muckpot-infra/src/main/kotlin/com/yapp/muckpot/email/EmailTemplate.kt
+++ b/muckpot-infra/src/main/kotlin/com/yapp/muckpot/email/EmailTemplate.kt
@@ -4,7 +4,9 @@ enum class EmailTemplate(
     val subject: String,
     private val body: String
 ) {
-    // 인증 번호
+    /**
+     * body: 인증 번호
+     */
     AUTH_EMAIL(
         "먹팟 이메일 인증 요청입니다.",
         MAIL_BASIC_FORMAT.format(
@@ -17,7 +19,10 @@ enum class EmailTemplate(
         )
     ),
 
-    // 먹팟 기존 글 제목, 변경 내용
+    /**
+     * subject: 먹팟 기존 글 제목
+     * body: 먹팟 기존 글 제목, 변경 내용
+     */
     BOARD_UPDATE_EMAIL(
         "신청하신 \"%s\"을 작성자가 수정했습니다.",
         MAIL_BASIC_FORMAT.format(
@@ -29,7 +34,10 @@ enum class EmailTemplate(
         )
     ),
 
-    // 먹팟 기존 글 제목, 변경 내용
+    /**
+     * subject: 먹팟 기존 글 제목
+     * body: 먹팟 기존 글 제목
+     */
     BOARD_DELETE_EMAIL(
         "신청하신 \"%s\"을 작성자가 삭제했습니다.",
         MAIL_BASIC_FORMAT.format(


### PR DESCRIPTION
## 개요
- close #100 

## 작업사항
- 먹팟 글 삭제시 메일 전송
- 자신에게는 메일을 보내지 않음.

## 변경로직
- 메일 조회 및 이메일 전송 기능이 중복사용되어 ParticipantService로 분리하였습니다.

## 확인
<img width="483" alt="image" src="https://github.com/YAPP-Github/mukpat-server/assets/26343023/68fc64ac-b838-4e41-8b49-9398e6b94d7b">
