### PR TITLE
feat: 102 먹팟 글 생성 api v2 개발

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/BoardController.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/BoardController.kt
@@ -9,6 +9,7 @@ import com.yapp.muckpot.common.dto.CursorPaginationRequest
 import com.yapp.muckpot.common.utils.ResponseEntityUtil
 import com.yapp.muckpot.common.utils.SecurityContextHolderUtil
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotCreateRequest
+import com.yapp.muckpot.domains.board.controller.dto.MuckpotCreateRequestV1
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotCreateResponse
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotUpdateRequest
 import com.yapp.muckpot.domains.board.service.BoardService
@@ -55,7 +56,7 @@ class BoardController(
         ]
     )
     @ApiOperation(value = "먹팟 글 생성")
-    @PostMapping("/v1/boards")
+    @PostMapping("/v2/boards")
     fun saveBoard(
         @AuthenticationPrincipal userId: Long,
         @RequestBody @Valid
@@ -203,5 +204,34 @@ class BoardController(
     ): ResponseEntity<ResponseDto> {
         boardService.cancelJoin(userId, boardId)
         return ResponseEntityUtil.noContent()
+    }
+
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                code = 201,
+                examples = Example(
+                    ExampleProperty(
+                        value = MUCKPOT_SAVE_RESPONSE,
+                        mediaType = MediaType.APPLICATION_JSON_VALUE
+                    )
+                ),
+                message = "성공"
+            )
+        ]
+    )
+    @ApiOperation(value = "먹팟 글 생성 - v1")
+    @PostMapping("/v1/boards")
+    @Deprecated("V2 배포 후 제거")
+    fun saveBoardV1(
+        @AuthenticationPrincipal userId: Long,
+        @RequestBody @Valid
+        request: MuckpotCreateRequestV1
+    ): ResponseEntity<ResponseDto> {
+        return ResponseEntityUtil.created(
+            MuckpotCreateResponse(
+                boardService.saveBoardV1(userId, request)
+            )
+        )
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequestV1.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequestV1.kt
@@ -15,7 +15,6 @@ import com.yapp.muckpot.common.constants.TITLE_MAX
 import com.yapp.muckpot.common.constants.TITLE_MAX_INVALID
 import com.yapp.muckpot.common.constants.YYYYMMDD
 import com.yapp.muckpot.domains.board.entity.Board
-import com.yapp.muckpot.domains.board.entity.Province
 import com.yapp.muckpot.domains.user.entity.MuckPotUser
 import io.swagger.annotations.ApiModel
 import io.swagger.annotations.ApiModelProperty
@@ -26,8 +25,9 @@ import java.time.LocalTime
 import javax.validation.constraints.Min
 import javax.validation.constraints.NotBlank
 
-@ApiModel(value = "먹팟생성 요청")
-data class MuckpotCreateRequest(
+@Deprecated("V2 배포 후 제거")
+@ApiModel(value = "먹팟 글 생성 V1")
+data class MuckpotCreateRequestV1(
     @field:ApiModelProperty(notes = "만날 날짜", required = true, example = "2023-05-21")
     @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = YYYYMMDD)
     val meetingDate: LocalDate,
@@ -59,24 +59,16 @@ data class MuckpotCreateRequest(
     @field:ApiModelProperty(notes = "오픈채팅방 링크", required = true, example = "https://open.kakao.com/o/gSIkvvHc")
     @field:Length(max = CHAT_LINK_MAX, message = LINK_MAX_INVALID)
     @field:NotBlank(message = NOT_BLANK_COMMON)
-    var chatLink: String,
-    @field:ApiModelProperty(notes = "시/도", required = true, example = "경기도")
-    @field:NotBlank(message = NOT_BLANK_COMMON)
-    var region_1depth_name: String,
-    @field:ApiModelProperty(notes = "구/군", required = true, example = "용인시 기흥구")
-    @field:NotBlank(message = NOT_BLANK_COMMON)
-    var region_2depth_name: String
+    var chatLink: String
 ) {
     init {
         title = title.trim()
         content = content?.trim()
         chatLink = chatLink.trim()
         locationDetail = locationDetail?.trim()
-        region_1depth_name = region_1depth_name.trim()
-        region_2depth_name = region_2depth_name.trim()
     }
 
-    fun toBoard(user: MuckPotUser, province: Province): Board {
+    fun toBoard(user: MuckPotUser): Board {
         return Board(
             user = user,
             title = title,
@@ -88,8 +80,7 @@ data class MuckpotCreateRequest(
             maxAge = maxAge ?: AGE_MAX,
             maxApply = maxApply,
             chatLink = chatLink,
-            currentApply = 1,
-            province = province
+            currentApply = 1
         )
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
@@ -41,13 +41,16 @@ class BoardService(
     private val cityRepository: CityRepository,
     private val provinceRepository: ProvinceRepository
 ) {
+    fun getMuckpotProvince(depth1: String, depth2: String): Province {
+        val city = cityRepository.findByName(depth1) ?: cityRepository.save(City(depth1))
+        return provinceRepository.findByName(depth2) ?: provinceRepository.save(Province(depth2, city))
+    }
+
     @Transactional
     fun saveBoard(userId: Long, request: MuckpotCreateRequest): Long? {
-        // TODO 먹팟 등록 시 같은 회사 인원에게 메일 전송
         val user = userRepository.findByIdOrNull(userId)
             ?: throw MuckPotException(UserErrorCode.USER_NOT_FOUND)
-        val city = cityRepository.findByName(request.region_1depth_name) ?: cityRepository.save(City(request.region_1depth_name))
-        val province = provinceRepository.findByName(request.region_2depth_name) ?: provinceRepository.save(Province(request.region_2depth_name, city))
+        val province = getMuckpotProvince(request.region_1depth_name, request.region_2depth_name)
         val board = boardRepository.save(request.toBoard(user, province))
         participantRepository.save(Participant(user, board))
         return board.id

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/ProvinceService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/ProvinceService.kt
@@ -1,0 +1,18 @@
+package com.yapp.muckpot.domains.board.service
+
+import com.yapp.muckpot.domains.board.entity.City
+import com.yapp.muckpot.domains.board.entity.Province
+import com.yapp.muckpot.domains.board.repository.CityRepository
+import com.yapp.muckpot.domains.board.repository.ProvinceRepository
+import org.springframework.stereotype.Service
+
+@Service
+class ProvinceService(
+    private val cityRepository: CityRepository,
+    private val provinceRepository: ProvinceRepository
+) {
+    fun saveProvinceIfNot(cityName: String, provinceName: String): Province {
+        val city = cityRepository.findByName(cityName) ?: cityRepository.save(City(cityName))
+        return provinceRepository.findByName(provinceName) ?: provinceRepository.save(Province(provinceName, city))
+    }
+}

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/LoginRequest.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/LoginRequest.kt
@@ -14,7 +14,7 @@ data class LoginRequest(
     @field:ApiModelProperty(notes = "이메일", required = true, example = "user@naver.com")
     @field:Pattern(regexp = ONLY_NAVER, message = "현재 버전은 네이버 사우만 이용 가능합니다.")
     val email: String,
-    @field:ApiModelProperty(notes = "비밀번호", required = true, example = "abcd1234")
+    @field:ApiModelProperty(notes = "비밀번호", required = true, example = "abc12345")
     @field:Pattern(
         regexp = PW_PATTERN,
         message = PASSWORD_PATTERN_INVALID

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/SignUpRequestV1.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/SignUpRequestV1.kt
@@ -14,7 +14,7 @@ import javax.validation.constraints.Size
 @Deprecated("V2 배포 후 제거")
 @ApiModel(value = "회원가입 V1")
 data class SignUpRequestV1(
-    @field:ApiModelProperty(notes = "이메일", required = true, example = "co@naver.com")
+    @field:ApiModelProperty(notes = "이메일", required = true, example = "user@naver.com")
     @field:Pattern(regexp = ONLY_NAVER, message = "현재 버전은 네이버 사우만 이용 가능합니다.")
     val email: String,
 

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequestTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequestTest.kt
@@ -27,7 +27,9 @@ class MuckpotCreateRequestTest : StringSpec({
         y: Double = 0.0,
         title: String = "title",
         content: String? = null,
-        chatLink: String = "chat_link"
+        chatLink: String = "chat_link",
+        region_1depth_name: String = "서울특별시",
+        region_2depth_name: String = "강남구"
     ): MuckpotCreateRequest {
         return MuckpotCreateRequest(
             meetingDate = meetingDate,
@@ -41,7 +43,9 @@ class MuckpotCreateRequestTest : StringSpec({
             y = y,
             title = title,
             content = content,
-            chatLink = chatLink
+            chatLink = chatLink,
+            region_1depth_name = region_1depth_name,
+            region_2depth_name = region_2depth_name
         )
     }
 
@@ -81,6 +85,26 @@ class MuckpotCreateRequestTest : StringSpec({
 
     "chatLink는 공백이 될 수 없다." {
         val request = createMuckpotCreateRequest(chatLink = "  ")
+
+        val violations: MutableSet<ConstraintViolation<MuckpotCreateRequest>> = validator.validate(request)
+        violations.size shouldBe 1
+        for (violation in violations) {
+            violation.message shouldBe NOT_BLANK_COMMON
+        }
+    }
+
+    "시/도는 공백이 될 수 없다." {
+        val request = createMuckpotCreateRequest(region_1depth_name = " ")
+
+        val violations: MutableSet<ConstraintViolation<MuckpotCreateRequest>> = validator.validate(request)
+        violations.size shouldBe 1
+        for (violation in violations) {
+            violation.message shouldBe NOT_BLANK_COMMON
+        }
+    }
+
+    "구/군은 공백이 될 수 없다." {
+        val request = createMuckpotCreateRequest(region_2depth_name = " ")
 
         val violations: MutableSet<ConstraintViolation<MuckpotCreateRequest>> = validator.validate(request)
         violations.size shouldBe 1

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/City.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/City.kt
@@ -34,4 +34,5 @@ class City(
     init {
         require(name.isNotBlank()) { "name은 필수입니다" }
     }
+    constructor(name: String) : this(null, name = name)
 }

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Province.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Province.kt
@@ -41,4 +41,5 @@ class Province(
     init {
         require(name.isNotBlank()) { "name은 필수입니다" }
     }
+    constructor(name: String, city: City) : this(null, name = name, city = city)
 }

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/repository/CityRepository.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/repository/CityRepository.kt
@@ -1,0 +1,8 @@
+package com.yapp.muckpot.domains.board.repository
+
+import com.yapp.muckpot.domains.board.entity.City
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CityRepository : JpaRepository<City, Long> {
+    fun findByName(name: String): City?
+}

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/repository/ProvinceRepository.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/repository/ProvinceRepository.kt
@@ -1,0 +1,8 @@
+package com.yapp.muckpot.domains.board.repository
+
+import com.yapp.muckpot.domains.board.entity.Province
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ProvinceRepository : JpaRepository<Province, Long> {
+    fun findByName(name: String): Province?
+}


### PR DESCRIPTION
## 개요
- close #102 

## 작업사항
- 먹팟 글 생성 api v2 개발
- 먹팟 생성 시 새로운 지역의 경우 최초 1회만 city, province 테이블에 값 저장
- 먹팟 글 생성 관련 테스트 코드 작성 및 수정

## 변경사항
스웨거 회원가입, 로그인 예시 요청 값 통일하여 예시 요청 값 그대로 api 사용 가능하게 변경했습니다.