### PR TITLE
fix: 108 오늘내일 데이터 오류 개선

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotReadResponse.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotReadResponse.kt
@@ -5,7 +5,6 @@ import com.yapp.muckpot.common.constants.KR_MM_DD_E
 import com.yapp.muckpot.common.constants.a_hhmm
 import com.yapp.muckpot.domains.board.dto.ParticipantReadResponse
 import com.yapp.muckpot.domains.board.entity.Board
-import com.yapp.muckpot.domains.user.enums.MuckPotStatus
 
 data class MuckpotReadResponse(
     val boardId: Long,
@@ -34,16 +33,11 @@ data class MuckpotReadResponse(
         private const val PARTICIPANTS_MAX_CNT = 5
 
         fun of(board: Board, participants: List<ParticipantReadResponse>): MuckpotReadResponse {
-            // TODO 만료 된 먹팟 종료 처리 후, 해당 로직은 제거.
-            var status = board.status.korNm
-            if (board.expired()) {
-                status = MuckPotStatus.DONE.korNm
-            }
             return MuckpotReadResponse(
                 boardId = board.id ?: 0,
                 title = board.title,
-                status = status,
-                todayOrTomorrow = TimeUtil.isTodayOrTomorrow(board.createdAt.toLocalDate()),
+                status = board.status.korNm,
+                todayOrTomorrow = TimeUtil.isTodayOrTomorrow(board.meetingTime.toLocalDate()),
                 elapsedTime = TimeUtil.formatElapsedTime(board.createdAt),
                 meetingDateTime = TimeUtil.localeKoreanFormatting(board.meetingTime, "$KR_MM_DD_E $a_hhmm"),
                 meetingPlace = board.location.locationName,

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceMockTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceMockTest.kt
@@ -2,6 +2,8 @@ package com.yapp.muckpot.domains.board.service
 
 import Fixture
 import com.ninjasquad.springmockk.MockkBean
+import com.yapp.muckpot.common.constants.TODAY_KR
+import com.yapp.muckpot.common.constants.TOMORROW_KR
 import com.yapp.muckpot.common.dto.CursorPaginationRequest
 import com.yapp.muckpot.domains.board.dto.ParticipantReadResponse
 import com.yapp.muckpot.domains.board.repository.BoardQuerydslRepository
@@ -32,8 +34,8 @@ class BoardServiceMockTest @Autowired constructor(
         val allBoardSize = 3
         val allBoard = listOf(
             Fixture.createBoard(id = 1, title = "board1").apply { meetingTime = LocalDateTime.MIN },
-            Fixture.createBoard(id = 2, title = "board2"),
-            Fixture.createBoard(id = 3, title = "board3")
+            Fixture.createBoard(id = 2, title = "board2").apply { meetingTime = LocalDateTime.now() },
+            Fixture.createBoard(id = 3, title = "board3").apply { meetingTime = LocalDateTime.now().plusDays(1) }
         )
         val participantResponses = listOf(
             ParticipantReadResponse(boardId = 1, userId = 1, nickName = "user1"),
@@ -68,12 +70,12 @@ class BoardServiceMockTest @Autowired constructor(
             actual.list[0].participants.last().nickName shouldBe "외 3명"
         }
 
-        test("현재 시간 이전인 경우 모집마감 으로 바꾸어 응답한다.") {
-
+        test("오늘, 내일은 meetingTime 기준으로 생성된다.") {
             // when
             val actual = boardService.findAllMuckpot(CursorPaginationRequest(null, allBoardSize.toLong()))
             // then
-            actual.list[0].status shouldBe MuckPotStatus.DONE.korNm
+            actual.list[1].todayOrTomorrow shouldBe TODAY_KR
+            actual.list[2].todayOrTomorrow shouldBe TOMORROW_KR
         }
     }
 


### PR DESCRIPTION
- 오늘, 내일 데이터가 createAt 기준으로 생성되고 있어, meetingTime으로 변경하였습니다.
- [QA 노션 링크
](https://www.notion.so/yapp-workspace/2ac19bc223034e919f062dec168d68f6?pvs=4)
## 개요
- close #108 

## 작업사항
- 오늘 내일 데이터 기준 변경

## 변경로직
- createdAt이 아닌 meetingTime 기준으로 생성되도록 변경

## 🕵🏻‍♀️    에러 상황
- 오늘(7월 8일)이고, 먹팟 날짜가 9월 27일 인데.. 오늘이 표시되고 있음.
![image](https://github.com/YAPP-Github/mukpat-server/assets/26343023/9d13a247-7834-416e-986a-137cd430c0f8)