### PR TITLE
fix: 108 timeZone 9시간 차이나서 수정

### DIFF
--- a/muckpot-api/Dockerfile
+++ b/muckpot-api/Dockerfile
@@ -9,4 +9,4 @@ COPY ${JAR_FILE} app.jar
 ARG PROFILE=dev
 ENV PROFILE=${PROFILE}
 
-ENTRYPOINT ["java","-Dspring.profiles.active=${PROFILE}","-jar","/app.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=${PROFILE}", "-Duser.timezone=Asia/Seoul", "-jar", "/app.jar"]


### PR DESCRIPTION
## 개요
- close #108 

## 작업사항
- LocalDateTime이 9시간 차이나서 타임존 지정
- LocalDate.now() 로 비교할 때 현재시간과 9시간이 차이나고 있어서 문제가 되고 있습니다.
  - ex) 7월 9일 먹팟이 내일로 보여지고 있음.
![image](https://github.com/YAPP-Github/mukpat-server/assets/26343023/28f5f590-581b-41b2-9089-16df2edbede7)

## 변경로직
- Dockerfile에 타임존 지정하였습니다.