### PR TITLE
feat:111 로그인, 이메일 인증 요청, 검증 API 이메일 삼성으로 변경

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/constants/UrlConstant.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/constants/UrlConstant.kt
@@ -1,12 +1,22 @@
 package com.yapp.muckpot.common.constants
 
-const val LOGIN_URL = "/api/v1/users/login"
+const val LOGIN_URL = "/api/v2/users/login"
 const val SIGN_UP_URL = "/api/v2/users"
 
-@Deprecated("V2 배포 후 제거")
-const val SIGN_UP_URL_V1 = "/api/v1/users"
-const val EMAIL_REQUEST_URL = "/api/v1/emails/request"
-const val EMAIL_VERIFY_URL = "/api/v1/emails/verify"
+const val EMAIL_REQUEST_URL = "/api/v2/emails/request"
+const val EMAIL_VERIFY_URL = "/api/v2/emails/verify"
 const val USER_PROFILE_URL = "/api/v1/users/profile"
 const val LOGOUT_URL = "/api/v1/users/logout"
 const val REISSUE_JWT_URL = "/api/v1/users/refresh"
+
+@Deprecated("V2 배포 후 제거")
+const val SIGN_UP_URL_V1 = "/api/v1/users"
+
+@Deprecated("V2 배포 후 제거")
+const val LOGIN_URL_V1 = "/api/v1/users/login"
+
+@Deprecated("V2 배포 후 제거")
+const val EMAIL_REQUEST_URL_V1 = "/api/v1/emails/request"
+
+@Deprecated("V2 배포 후 제거")
+const val EMAIL_VERIFY_URL_V1 = "/api/v1/emails/verify"

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/config/SecurityConfig.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/config/SecurityConfig.kt
@@ -2,8 +2,11 @@ package com.yapp.muckpot.config
 
 import com.yapp.muckpot.common.constants.ACCESS_TOKEN_KEY
 import com.yapp.muckpot.common.constants.EMAIL_REQUEST_URL
+import com.yapp.muckpot.common.constants.EMAIL_REQUEST_URL_V1
 import com.yapp.muckpot.common.constants.EMAIL_VERIFY_URL
+import com.yapp.muckpot.common.constants.EMAIL_VERIFY_URL_V1
 import com.yapp.muckpot.common.constants.LOGIN_URL
+import com.yapp.muckpot.common.constants.LOGIN_URL_V1
 import com.yapp.muckpot.common.constants.LOGOUT_URL
 import com.yapp.muckpot.common.constants.REFRESH_TOKEN_KEY
 import com.yapp.muckpot.common.constants.REISSUE_JWT_URL
@@ -112,12 +115,15 @@ class SecurityConfig(
     companion object {
         val POST_PERMIT_ALL_URLS = listOf(
             LOGIN_URL,
-            SIGN_UP_URL_V1,
             SIGN_UP_URL,
             EMAIL_REQUEST_URL,
             EMAIL_VERIFY_URL,
             USER_PROFILE_URL,
-            REISSUE_JWT_URL
+            REISSUE_JWT_URL,
+            SIGN_UP_URL_V1,
+            LOGIN_URL_V1,
+            EMAIL_REQUEST_URL_V1,
+            EMAIL_VERIFY_URL_V1
         )
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/UserController.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/UserController.kt
@@ -12,7 +12,6 @@ import com.yapp.muckpot.common.utils.SecurityContextHolderUtil
 import com.yapp.muckpot.domains.user.controller.dto.LoginRequest
 import com.yapp.muckpot.domains.user.controller.dto.SendEmailAuthRequest
 import com.yapp.muckpot.domains.user.controller.dto.SignUpRequest
-import com.yapp.muckpot.domains.user.controller.dto.SignUpRequestV1
 import com.yapp.muckpot.domains.user.controller.dto.VerifyEmailAuthRequest
 import com.yapp.muckpot.domains.user.service.UserService
 import io.swagger.annotations.Api
@@ -53,7 +52,7 @@ class UserController(
         ]
     )
     @ApiOperation(value = "로그인")
-    @PostMapping("/v1/users/login")
+    @PostMapping("/v2/users/login")
     fun login(
         @RequestBody @Valid
         request: LoginRequest
@@ -76,7 +75,7 @@ class UserController(
         ]
     )
     @ApiOperation(value = "이메일 인증 요청")
-    @PostMapping("/v1/emails/request")
+    @PostMapping("/v2/emails/request")
     fun sendEmailAuth(
         @RequestBody @Valid
         request: SendEmailAuthRequest
@@ -99,7 +98,7 @@ class UserController(
         ]
     )
     @ApiOperation(value = "이메일 인증 검증")
-    @PostMapping("/v1/emails/verify")
+    @PostMapping("/v2/emails/verify")
     fun verifyEmailAuth(
         @RequestBody @Valid
         request: VerifyEmailAuthRequest
@@ -178,29 +177,5 @@ class UserController(
     fun reissueJwt(@CookieValue(REFRESH_TOKEN_KEY) refreshToken: String, @CookieValue(ACCESS_TOKEN_KEY) accessToken: String): ResponseEntity<ResponseDto> {
         userService.reissueJwt(refreshToken, accessToken)
         return ResponseEntityUtil.noContent()
-    }
-
-    @ApiResponses(
-        value = [
-            ApiResponse(
-                code = 201,
-                examples = Example(
-                    ExampleProperty(
-                        value = SIGN_UP_RESPONSE,
-                        mediaType = MediaType.APPLICATION_JSON_VALUE
-                    )
-                ),
-                message = "성공"
-            )
-        ]
-    )
-    @ApiOperation(value = "회원가입 - v1")
-    @PostMapping("/v1/users")
-    @Deprecated("V2 배포 후 제거")
-    fun signUpV1(
-        @RequestBody @Valid
-        request: SignUpRequestV1
-    ): ResponseEntity<ResponseDto> {
-        return ResponseEntityUtil.created(userService.signUpV1(request))
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/UserDeprecatedController.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/UserDeprecatedController.kt
@@ -1,0 +1,127 @@
+package com.yapp.muckpot.domains.user.controller
+
+import com.yapp.muckpot.common.ResponseDto
+import com.yapp.muckpot.common.constants.EMAIL_AUTH_REQ_RESPONSE
+import com.yapp.muckpot.common.constants.LOGIN_RESPONSE
+import com.yapp.muckpot.common.constants.NO_BODY_RESPONSE
+import com.yapp.muckpot.common.constants.SIGN_UP_RESPONSE
+import com.yapp.muckpot.common.utils.ResponseEntityUtil
+import com.yapp.muckpot.domains.user.controller.dto.deprecated.LoginRequestV1
+import com.yapp.muckpot.domains.user.controller.dto.deprecated.SendEmailAuthRequestV1
+import com.yapp.muckpot.domains.user.controller.dto.deprecated.SignUpRequestV1
+import com.yapp.muckpot.domains.user.controller.dto.deprecated.VerifyEmailAuthRequestV1
+import com.yapp.muckpot.domains.user.service.UserDeprecatedService
+import io.swagger.annotations.Api
+import io.swagger.annotations.ApiOperation
+import io.swagger.annotations.ApiResponse
+import io.swagger.annotations.ApiResponses
+import io.swagger.annotations.Example
+import io.swagger.annotations.ExampleProperty
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import javax.validation.Valid
+
+@Deprecated("V2 배포 후 제거")
+@RestController
+@Api(tags = ["유저 api - Deprecated"], description = "유저 API - Deprecated")
+@RequestMapping("/api")
+class UserDeprecatedController(
+    private val userDeprecatedService: UserDeprecatedService
+) {
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                code = 201,
+                examples = Example(
+                    ExampleProperty(
+                        value = SIGN_UP_RESPONSE,
+                        mediaType = MediaType.APPLICATION_JSON_VALUE
+                    )
+                ),
+                message = "성공"
+            )
+        ]
+    )
+    @ApiOperation(value = "회원가입 - v1")
+    @PostMapping("/v1/users")
+    fun signUpV1(
+        @RequestBody @Valid
+        request: SignUpRequestV1
+    ): ResponseEntity<ResponseDto> {
+        return ResponseEntityUtil.created(userDeprecatedService.signUpV1(request))
+    }
+
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                code = 201,
+                examples = Example(
+                    ExampleProperty(
+                        value = EMAIL_AUTH_REQ_RESPONSE,
+                        mediaType = MediaType.APPLICATION_JSON_VALUE
+                    )
+                ),
+                message = "성공"
+            )
+        ]
+    )
+    @ApiOperation(value = "이메일 인증 요청 - v1")
+    @PostMapping("/v1/emails/request")
+    fun sendEmailAuthV1(
+        @RequestBody @Valid
+        request: SendEmailAuthRequestV1
+    ): ResponseEntity<ResponseDto> {
+        return ResponseEntityUtil.created(userDeprecatedService.sendEmailAuthV1(request))
+    }
+
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                code = 204,
+                examples = Example(
+                    ExampleProperty(
+                        value = NO_BODY_RESPONSE,
+                        mediaType = MediaType.APPLICATION_JSON_VALUE
+                    )
+                ),
+                message = "성공"
+            )
+        ]
+    )
+    @ApiOperation(value = "이메일 인증 검증 - v1")
+    @PostMapping("/v1/emails/verify")
+    fun verifyEmailAuthV1(
+        @RequestBody @Valid
+        request: VerifyEmailAuthRequestV1
+    ): ResponseEntity<ResponseDto> {
+        userDeprecatedService.verifyEmailAuthV1(request)
+        return ResponseEntityUtil.noContent()
+    }
+
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                code = 200,
+                examples = Example(
+                    ExampleProperty(
+                        value = LOGIN_RESPONSE,
+                        mediaType = MediaType.APPLICATION_JSON_VALUE
+                    )
+                ),
+                message = "성공"
+            )
+        ]
+    )
+    @ApiOperation(value = "로그인 - v1")
+    @PostMapping("/v1/users/login")
+    fun loginV1(
+        @RequestBody @Valid
+        request: LoginRequestV1
+    ): ResponseEntity<ResponseDto> {
+        return ResponseEntityUtil.ok(userDeprecatedService.loginV1(request))
+    }
+}

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/LoginRequest.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/LoginRequest.kt
@@ -1,6 +1,7 @@
 package com.yapp.muckpot.domains.user.controller.dto
 
-import com.yapp.muckpot.common.constants.ONLY_NAVER
+import com.yapp.muckpot.common.constants.ONLY_SAMSUNG
+import com.yapp.muckpot.common.constants.ONLY_SAMSUNG_EXP_MSG
 import com.yapp.muckpot.common.constants.PASSWORD_PATTERN_INVALID
 import com.yapp.muckpot.common.constants.PW_PATTERN
 import com.yapp.muckpot.common.enums.YesNo
@@ -10,11 +11,10 @@ import javax.validation.constraints.Pattern
 
 @ApiModel(value = "로그인 요청")
 data class LoginRequest(
-    // TODO 상용 시 samsung.com 으로 변경
-    @field:ApiModelProperty(notes = "이메일", required = true, example = "user@naver.com")
-    @field:Pattern(regexp = ONLY_NAVER, message = "현재 버전은 네이버 사우만 이용 가능합니다.")
+    @field:ApiModelProperty(notes = "이메일", required = true, example = "user@samsung.com")
+    @field:Pattern(regexp = ONLY_SAMSUNG, message = ONLY_SAMSUNG_EXP_MSG)
     val email: String,
-    @field:ApiModelProperty(notes = "비밀번호", required = true, example = "abcd1234")
+    @field:ApiModelProperty(notes = "비밀번호", required = true, example = "abc12345")
     @field:Pattern(
         regexp = PW_PATTERN,
         message = PASSWORD_PATTERN_INVALID

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/SendEmailAuthRequest.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/SendEmailAuthRequest.kt
@@ -1,14 +1,14 @@
 package com.yapp.muckpot.domains.user.controller.dto
 
-import com.yapp.muckpot.common.constants.ONLY_NAVER
+import com.yapp.muckpot.common.constants.ONLY_SAMSUNG
+import com.yapp.muckpot.common.constants.ONLY_SAMSUNG_EXP_MSG
 import io.swagger.annotations.ApiModel
 import io.swagger.annotations.ApiModelProperty
 import javax.validation.constraints.Pattern
 
 @ApiModel(value = "이메일 인증 요청")
 data class SendEmailAuthRequest(
-    // TODO: 개발 서버에서 메일 정상 작동 확인 후 삼성전자로 변경 필요!
-    @field:ApiModelProperty(notes = "이메일", required = true, example = "co@naver.com")
-    @field:Pattern(regexp = ONLY_NAVER, message = "현재 버전은 네이버 사우만 이용 가능합니다.") // for test
+    @field:ApiModelProperty(notes = "이메일", required = true, example = "user@samsung.com")
+    @field:Pattern(regexp = ONLY_SAMSUNG, message = ONLY_SAMSUNG_EXP_MSG)
     val email: String
 )

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/SignUpRequest.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/SignUpRequest.kt
@@ -1,6 +1,7 @@
 package com.yapp.muckpot.domains.user.controller.dto
 
 import com.yapp.muckpot.common.constants.ONLY_SAMSUNG
+import com.yapp.muckpot.common.constants.ONLY_SAMSUNG_EXP_MSG
 import com.yapp.muckpot.common.constants.PASSWORD_PATTERN_INVALID
 import com.yapp.muckpot.common.constants.PW_PATTERN
 import com.yapp.muckpot.common.enums.Gender
@@ -14,7 +15,7 @@ import javax.validation.constraints.Size
 @ApiModel(value = "회원가입")
 data class SignUpRequest(
     @field:ApiModelProperty(notes = "이메일", required = true, example = "user@samsung.com")
-    @field:Pattern(regexp = ONLY_SAMSUNG, message = "현재 버전은 삼성전자 사우만 이용 가능합니다.")
+    @field:Pattern(regexp = ONLY_SAMSUNG, message = ONLY_SAMSUNG_EXP_MSG)
     val email: String,
 
     @field:ApiModelProperty(notes = "비밀번호", required = true, example = "abc12345")

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/VerifyEmailAuthRequest.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/VerifyEmailAuthRequest.kt
@@ -1,15 +1,15 @@
 package com.yapp.muckpot.domains.user.controller.dto
 
+import com.yapp.muckpot.common.constants.ONLY_SAMSUNG
+import com.yapp.muckpot.common.constants.ONLY_SAMSUNG_EXP_MSG
 import io.swagger.annotations.ApiModel
 import io.swagger.annotations.ApiModelProperty
 import javax.validation.constraints.Pattern
 
 @ApiModel(value = "이메일 인증 검증")
 data class VerifyEmailAuthRequest(
-    // TODO: 개발 서버에서 메일 정상 작동 확인 후 삼성전자로 변경 필요!
-    // @field:Pattern(regexp = "^[A-Za-z0-9._%+-]+@samsung\\.com\$", message = "현재 버전은 삼성전자 사우만 이용 가능합니다.")
-    @field:ApiModelProperty(notes = "이메일", required = true, example = "co@naver.com")
-    @field:Pattern(regexp = "^[A-Za-z0-9._%+-]+@naver\\.com\$", message = "현재 버전은 네이버 사우만 이용 가능합니다.") // for test
+    @field:ApiModelProperty(notes = "이메일", required = true, example = "user@samsung.com")
+    @field:Pattern(regexp = ONLY_SAMSUNG, message = ONLY_SAMSUNG_EXP_MSG)
     val email: String,
     @field:ApiModelProperty(notes = "인증 번호", required = true, example = "123456")
     val verificationCode: String

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/deprecated/LoginRequestV1.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/deprecated/LoginRequestV1.kt
@@ -15,7 +15,7 @@ data class LoginRequestV1(
     @field:ApiModelProperty(notes = "이메일", required = true, example = "user@naver.com")
     @field:Pattern(regexp = ONLY_NAVER, message = "현재 버전은 네이버 사우만 이용 가능합니다.")
     val email: String,
-    @field:ApiModelProperty(notes = "비밀번호", required = true, example = "abcd1234")
+    @field:ApiModelProperty(notes = "비밀번호", required = true, example = "abc12345")
     @field:Pattern(
         regexp = PW_PATTERN,
         message = PASSWORD_PATTERN_INVALID

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/deprecated/LoginRequestV1.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/deprecated/LoginRequestV1.kt
@@ -1,0 +1,26 @@
+package com.yapp.muckpot.domains.user.controller.dto.deprecated
+
+import com.yapp.muckpot.common.constants.ONLY_NAVER
+import com.yapp.muckpot.common.constants.PASSWORD_PATTERN_INVALID
+import com.yapp.muckpot.common.constants.PW_PATTERN
+import com.yapp.muckpot.common.enums.YesNo
+import io.swagger.annotations.ApiModel
+import io.swagger.annotations.ApiModelProperty
+import javax.validation.constraints.Pattern
+
+@Deprecated("V2 배포 후 제거")
+@ApiModel(value = "로그인 요청 - v1")
+data class LoginRequestV1(
+    // TODO 상용 시 samsung.com 으로 변경
+    @field:ApiModelProperty(notes = "이메일", required = true, example = "user@naver.com")
+    @field:Pattern(regexp = ONLY_NAVER, message = "현재 버전은 네이버 사우만 이용 가능합니다.")
+    val email: String,
+    @field:ApiModelProperty(notes = "비밀번호", required = true, example = "abcd1234")
+    @field:Pattern(
+        regexp = PW_PATTERN,
+        message = PASSWORD_PATTERN_INVALID
+    )
+    val password: String,
+    @field:ApiModelProperty(notes = "로그인 유지하기", required = true, example = "Y")
+    val keep: YesNo = YesNo.Y
+)

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/deprecated/SendEmailAuthRequestV1.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/deprecated/SendEmailAuthRequestV1.kt
@@ -1,0 +1,15 @@
+package com.yapp.muckpot.domains.user.controller.dto.deprecated
+
+import com.yapp.muckpot.common.constants.ONLY_NAVER
+import io.swagger.annotations.ApiModel
+import io.swagger.annotations.ApiModelProperty
+import javax.validation.constraints.Pattern
+
+@Deprecated("V2 배포 후 제거")
+@ApiModel(value = "이메일 인증 요청 - v1")
+data class SendEmailAuthRequestV1(
+    // TODO: 개발 서버에서 메일 정상 작동 확인 후 삼성전자로 변경 필요!
+    @field:ApiModelProperty(notes = "이메일", required = true, example = "co@naver.com")
+    @field:Pattern(regexp = ONLY_NAVER, message = "현재 버전은 네이버 사우만 이용 가능합니다.") // for test
+    val email: String
+)

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/deprecated/SignUpRequestV1.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/deprecated/SignUpRequestV1.kt
@@ -1,4 +1,4 @@
-package com.yapp.muckpot.domains.user.controller.dto
+package com.yapp.muckpot.domains.user.controller.dto.deprecated
 
 import com.yapp.muckpot.common.constants.ONLY_NAVER
 import com.yapp.muckpot.common.constants.PASSWORD_PATTERN_INVALID
@@ -12,7 +12,7 @@ import javax.validation.constraints.Pattern
 import javax.validation.constraints.Size
 
 @Deprecated("V2 배포 후 제거")
-@ApiModel(value = "회원가입 V1")
+@ApiModel(value = "회원가입 - v1")
 data class SignUpRequestV1(
     @field:ApiModelProperty(notes = "이메일", required = true, example = "co@naver.com")
     @field:Pattern(regexp = ONLY_NAVER, message = "현재 버전은 네이버 사우만 이용 가능합니다.")

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/deprecated/VerifyEmailAuthRequestV1.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/deprecated/VerifyEmailAuthRequestV1.kt
@@ -1,0 +1,18 @@
+package com.yapp.muckpot.domains.user.controller.dto.deprecated
+
+import com.yapp.muckpot.common.constants.ONLY_NAVER
+import io.swagger.annotations.ApiModel
+import io.swagger.annotations.ApiModelProperty
+import javax.validation.constraints.Pattern
+
+@Deprecated("V2 배포 후 제거")
+@ApiModel(value = "이메일 인증 검증 - v1")
+data class VerifyEmailAuthRequestV1(
+    // TODO: 개발 서버에서 메일 정상 작동 확인 후 삼성전자로 변경 필요!
+    // @field:Pattern(regexp = "^[A-Za-z0-9._%+-]+@samsung\\.com\$", message = "현재 버전은 삼성전자 사우만 이용 가능합니다.")
+    @field:ApiModelProperty(notes = "이메일", required = true, example = "co@naver.com")
+    @field:Pattern(regexp = ONLY_NAVER, message = "현재 버전은 네이버 사우만 이용 가능합니다.") // for test
+    val email: String,
+    @field:ApiModelProperty(notes = "인증 번호", required = true, example = "123456")
+    val verificationCode: String
+)

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/filter/JwtAuthorizationFilter.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/filter/JwtAuthorizationFilter.kt
@@ -1,6 +1,7 @@
 package com.yapp.muckpot.filter
 
 import com.yapp.muckpot.common.constants.LOGIN_URL
+import com.yapp.muckpot.common.constants.LOGIN_URL_V1
 import com.yapp.muckpot.common.constants.SIGN_UP_URL
 import com.yapp.muckpot.common.constants.SIGN_UP_URL_V1
 import com.yapp.muckpot.common.security.AuthenticationUser
@@ -36,7 +37,8 @@ class JwtAuthorizationFilter(private val jwtService: JwtService) : OncePerReques
         private val ALREADY_LOGIN_REJECT_URLS = listOf(
             LOGIN_URL,
             SIGN_UP_URL,
-            SIGN_UP_URL_V1
+            SIGN_UP_URL_V1,
+            LOGIN_URL_V1
         )
     }
 }

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/constants/BoardConstant.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/constants/BoardConstant.kt
@@ -10,3 +10,4 @@ const val MAX_APPLY_MIN = 2
 
 // 예외 메시지
 const val AGE_EXP_MSG = "나이는 $AGE_MIN ~ $AGE_MAX 범위로 입력해주세요."
+const val ONLY_SAMSUNG_EXP_MSG = "현재 버전은 삼성전자 사우만 이용 가능합니다."


### PR DESCRIPTION
## 개요
- close #111

## 작업사항
- 로그인, 이메일 인증 요청, 이메일 인증 검증 API 유효성 검사 변경
  - as-is: naver.com
  - to-be: samsung.com

## 변경로직
- Deprecated 대상이 너무 많아져서.. 클래스를 분리했습니다.