### PR TITLE
feat: 상세 조회 지역정보 쿼리파라미터 추가

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/BoardController.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/BoardController.kt
@@ -12,6 +12,7 @@ import com.yapp.muckpot.common.utils.SecurityContextHolderUtil
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotCreateRequest
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotCreateResponse
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotUpdateRequest
+import com.yapp.muckpot.domains.board.controller.dto.RegionFilterRequest
 import com.yapp.muckpot.domains.board.service.BoardService
 import com.yapp.muckpot.domains.user.enums.MuckPotStatus
 import io.swagger.annotations.Api
@@ -105,11 +106,13 @@ class BoardController(
     )
     @ApiOperation(value = "먹팟 글 상세 조회")
     @GetMapping("/v1/boards/{boardId}")
-    fun findByBoardId(@PathVariable boardId: Long): ResponseEntity<ResponseDto> {
+    fun findByBoardId(@PathVariable boardId: Long, request: RegionFilterRequest): ResponseEntity<ResponseDto> {
+        request.validate()
         return ResponseEntityUtil.ok(
             boardService.findBoardDetailAndVisit(
                 boardId,
-                SecurityContextHolderUtil.getCredentialOrNull()
+                SecurityContextHolderUtil.getCredentialOrNull(),
+                request
             )
         )
     }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/RegionFilterRequest.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/RegionFilterRequest.kt
@@ -1,0 +1,16 @@
+package com.yapp.muckpot.domains.board.controller.dto
+import io.swagger.annotations.ApiParam
+import java.lang.IllegalArgumentException
+
+data class RegionFilterRequest(
+    @field:ApiParam(value = "시/도 ID", required = false)
+    val cityId: Long? = null,
+    @field:ApiParam(value = "군/구 ID", required = false)
+    val provinceId: Long? = null
+) {
+    fun validate() {
+        if (provinceId != null && cityId == null) {
+            throw IllegalArgumentException("시/도 ID를 입력해 주세요.")
+        }
+    }
+}

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/RegionFilterRequest.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/RegionFilterRequest.kt
@@ -5,7 +5,7 @@ import java.lang.IllegalArgumentException
 data class RegionFilterRequest(
     @field:ApiParam(value = "시/도 ID", required = false)
     val cityId: Long? = null,
-    @field:ApiParam(value = "군/구 ID", required = false)
+    @field:ApiParam(value = "구/군 ID", required = false)
     val provinceId: Long? = null
 ) {
     fun validate() {

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
@@ -8,6 +8,7 @@ import com.yapp.muckpot.domains.board.controller.dto.MuckpotCreateRequest
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotDetailResponse
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotReadResponse
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotUpdateRequest
+import com.yapp.muckpot.domains.board.controller.dto.RegionFilterRequest
 import com.yapp.muckpot.domains.board.entity.Participant
 import com.yapp.muckpot.domains.board.exception.BoardErrorCode
 import com.yapp.muckpot.domains.board.exception.ParticipantErrorCode
@@ -68,7 +69,7 @@ class BoardService(
     }
 
     @Transactional
-    fun findBoardDetailAndVisit(boardId: Long, loginUserInfo: UserResponse?): MuckpotDetailResponse {
+    fun findBoardDetailAndVisit(boardId: Long, loginUserInfo: UserResponse?, request: RegionFilterRequest): MuckpotDetailResponse {
         boardRepository.findByIdOrNull(boardId)?.let { board ->
             if (board.user.id != loginUserInfo?.userId) {
                 board.visit()
@@ -78,8 +79,8 @@ class BoardService(
             return MuckpotDetailResponse.of(
                 board = board,
                 participants = participantQuerydslRepository.findByBoardIds(listOf(boardId)),
-                prevId = boardQuerydslRepository.findPrevId(boardId),
-                nextId = boardQuerydslRepository.findNextId(boardId),
+                prevId = boardQuerydslRepository.findPrevId(boardId, request.cityId, request.provinceId),
+                nextId = boardQuerydslRepository.findNextId(boardId, request.cityId, request.provinceId),
                 userAge = userAge
             ).apply {
                 sortParticipantsByLoginUser(loginUserInfo)

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceMockTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceMockTest.kt
@@ -5,6 +5,7 @@ import com.ninjasquad.springmockk.MockkBean
 import com.yapp.muckpot.common.constants.TODAY_KR
 import com.yapp.muckpot.common.constants.TOMORROW_KR
 import com.yapp.muckpot.common.dto.CursorPaginationRequest
+import com.yapp.muckpot.domains.board.controller.dto.RegionFilterRequest
 import com.yapp.muckpot.domains.board.dto.ParticipantReadResponse
 import com.yapp.muckpot.domains.board.dto.RegionDto
 import com.yapp.muckpot.domains.board.dto.RegionDto.CityDto
@@ -107,7 +108,7 @@ class BoardServiceMockTest @Autowired constructor(
 
         test("먹팟 상세조회 성공") {
             // when
-            val actual = boardService.findBoardDetailAndVisit(1, loginUser)
+            val actual = boardService.findBoardDetailAndVisit(1, loginUser, RegionFilterRequest())
 
             // then
             actual.meetingDate shouldBe "12월 25일 (토)"

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
@@ -5,6 +5,7 @@ import com.yapp.muckpot.common.enums.Gender
 import com.yapp.muckpot.common.redisson.ConcurrencyHelper
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotCreateRequest
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotUpdateRequest
+import com.yapp.muckpot.domains.board.controller.dto.RegionFilterRequest
 import com.yapp.muckpot.domains.board.entity.City
 import com.yapp.muckpot.domains.board.entity.Participant
 import com.yapp.muckpot.domains.board.entity.Province
@@ -23,7 +24,7 @@ import com.yapp.muckpot.exception.MuckPotException
 import com.yapp.muckpot.redis.RedisService
 import com.yapp.muckpot.redis.constants.REGIONS_CACHE_NAME
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.StringSpec
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -42,8 +43,9 @@ class BoardServiceTest @Autowired constructor(
     private val participantRepository: ParticipantRepository,
     private val cityRepository: CityRepository,
     private val provinceRepository: ProvinceRepository,
+    private val provinceService: ProvinceService,
     private val redisService: RedisService
-) : StringSpec({
+) : FunSpec({
     lateinit var user: MuckPotUser
     lateinit var province: Province
     lateinit var city: City
@@ -97,7 +99,7 @@ class BoardServiceTest @Autowired constructor(
         cityRepository.deleteAll()
     }
 
-    "먹팟 생성 성공" {
+    test("먹팟 생성 성공") {
         // when
         val boardId = boardService.saveBoard(userId, createRequest)
 
@@ -115,63 +117,51 @@ class BoardServiceTest @Autowired constructor(
         findProvince shouldNotBe null
     }
 
-    "자신의 글은 조회수가 증가하지 않는다." {
+    test("자신의 글은 조회수가 증가하지 않는다.") {
         // given
         val boardId = boardService.saveBoard(userId, createRequest)!!
         val loginUserInfo = UserResponse.of(user)
 
         // when
-        boardService.findBoardDetailAndVisit(boardId, loginUserInfo)
-        boardService.findBoardDetailAndVisit(boardId, loginUserInfo)
+        boardService.findBoardDetailAndVisit(boardId, loginUserInfo, RegionFilterRequest())
+        boardService.findBoardDetailAndVisit(boardId, loginUserInfo, RegionFilterRequest())
 
         // then
         val findBoard = boardRepository.findByIdOrNull(boardId)!!
         findBoard.views shouldBe 0
     }
 
-    "먹팟 상세 조회시 조회수가 증가한다." {
+    test("먹팟 상세 조회시 조회수가 증가한다.") {
         // given
         val boardId = boardService.saveBoard(userId, createRequest)!!
         val otherUser = UserResponse.of(userRepository.save(Fixture.createUser()))
 
         // when
-        boardService.findBoardDetailAndVisit(boardId, otherUser)
+        boardService.findBoardDetailAndVisit(boardId, otherUser, RegionFilterRequest())
 
         // then
         val findBoard = boardRepository.findByIdOrNull(boardId)!!
         findBoard.views shouldBe 1
     }
 
-    "비로그인 유저도 조회수가 증가한다." {
+    test("비로그인 유저도 조회수가 증가한다.") {
         // given
         val boardId = boardService.saveBoard(userId, createRequest)!!
         // when
-        boardService.findBoardDetailAndVisit(boardId, null)
+        boardService.findBoardDetailAndVisit(boardId, null, RegionFilterRequest())
         // then
         val findBoard = boardRepository.findByIdOrNull(boardId)!!
         findBoard.views shouldBe 1
     }
 
-    "이전, 이후 아이디도 함께 응답에 반환한다." {
-        // given
-        val prevBoardId = boardService.saveBoard(userId, createRequest)!!
-        val boardId = boardService.saveBoard(userId, createRequest)!!
-        val nextBoardId = boardService.saveBoard(userId, createRequest)!!
-        // when
-        val actual = boardService.findBoardDetailAndVisit(boardId, null)
-        // then
-        actual.prevId shouldBe nextBoardId
-        actual.nextId shouldBe prevBoardId
-    }
-
-    "먹팟 수정 성공" {
+    test("먹팟 수정 성공") {
         // given
         val boardId = boardService.saveBoard(userId, createRequest)!!
         // when
         boardService.updateBoardAndSendEmail(userId, boardId, updateRequest)
         // then
         val actual = boardRepository.findByIdOrNull(boardId)!!
-        val province = provinceRepository.findByName(updateRequest.region_2depth_name)
+        val findProvince = provinceRepository.findByName(updateRequest.region_2depth_name)
 
         actual.maxApply shouldBe updateRequest.maxApply
         actual.minAge shouldBe updateRequest.minAge
@@ -182,10 +172,10 @@ class BoardServiceTest @Autowired constructor(
         actual.title shouldBe updateRequest.title
         actual.content shouldBe updateRequest.content
         actual.chatLink shouldBe updateRequest.chatLink
-        actual.province!!.id.shouldBe(province!!.id)
+        actual.province!!.id.shouldBe(findProvince!!.id)
     }
 
-    "자신의 글만 수정할 수 있다." {
+    test("자신의 글만 수정할 수 있다.") {
         // given
         val otherUserId = -1L
         val boardId = boardService.saveBoard(userId, createRequest)!!
@@ -195,7 +185,7 @@ class BoardServiceTest @Autowired constructor(
         }.errorCode shouldBe BoardErrorCode.BOARD_UNAUTHORIZED
     }
 
-    "먹팟 참가 신청 성공" {
+    test("먹팟 참가 신청 성공") {
         // given
         val boardId = boardService.saveBoard(userId, createRequest)!!
         val applyUser = userRepository.save(
@@ -216,14 +206,14 @@ class BoardServiceTest @Autowired constructor(
         participant shouldNotBe null
     }
 
-    "먹팟 중복 참가 신청 불가 검증" {
+    test("먹팟 중복 참가 신청 불가 검증") {
         val boardId = boardService.saveBoard(userId, createRequest)!!
         shouldThrow<MuckPotException> {
             boardService.joinBoard(userId, boardId)
         }.errorCode shouldBe ParticipantErrorCode.ALREADY_JOIN
     }
 
-    "먹팟 참가 동시성 테스트" {
+    test("먹팟 참가 동시성 테스트") {
         // given
         val boardId = boardService.saveBoard(userId, createRequest)!!
         val applyUser = userRepository.save(
@@ -246,7 +236,7 @@ class BoardServiceTest @Autowired constructor(
         findBoard.currentApply shouldBe 2
     }
 
-    "먹팟 삭제 요청시 INACTIVE로 변경된다." {
+    test("먹팟 삭제 요청시 INACTIVE로 변경된다.") {
         // given
         val boardId = boardService.saveBoard(userId, createRequest)!!
 
@@ -257,7 +247,7 @@ class BoardServiceTest @Autowired constructor(
         findBoard shouldBe null
     }
 
-    "자신의 글만 삭제할 수 있다." {
+    test("자신의 글만 삭제할 수 있다.") {
         // given
         val otherUserId = -1L
         val boardId = boardService.saveBoard(userId, createRequest)!!
@@ -267,7 +257,7 @@ class BoardServiceTest @Autowired constructor(
         }.errorCode shouldBe BoardErrorCode.BOARD_UNAUTHORIZED
     }
 
-    "글 삭제시 참여자 목록도 함께 삭제한다." {
+    test("글 삭제시 참여자 목록도 함께 삭제한다.") {
         // given
         val board = boardRepository.save(Fixture.createBoard(user = user, province = province))
         // when
@@ -277,7 +267,7 @@ class BoardServiceTest @Autowired constructor(
         findBoard shouldHaveSize 0
     }
 
-    "먹팟 상태변경 성공" {
+    test("먹팟 상태변경 성공") {
         // given
         val boardId = boardRepository.save(Fixture.createBoard(user = user, province = province)).id!!
         // when
@@ -287,7 +277,7 @@ class BoardServiceTest @Autowired constructor(
         actual.status shouldBe MuckPotStatus.DONE
     }
 
-    "먹팟 참가 신청 취소 성공" {
+    test("먹팟 참가 신청 취소 성공") {
         // given
         val applyUser = userRepository.save(Fixture.createUser())
         val board = boardRepository.save(Fixture.createBoard(user = user, province = province))
@@ -300,7 +290,7 @@ class BoardServiceTest @Autowired constructor(
         board.currentApply shouldBe 0
     }
 
-    "기존 참가 신청 내역 없으면 참가 신청 취소 불가" {
+    test("기존 참가 신청 내역 없으면 참가 신청 취소 불가") {
         // given
         val applyUser = userRepository.save(Fixture.createUser())
         val board = boardRepository.save(Fixture.createBoard(user = user, province = province))
@@ -310,7 +300,7 @@ class BoardServiceTest @Autowired constructor(
         }.errorCode shouldBe ParticipantErrorCode.PARTICIPANT_NOT_FOUND
     }
 
-    "먹팟 글 작성자는 참가 신청 취소할 수 없다." {
+    test("먹팟 글 작성자는 참가 신청 취소할 수 없다.") {
         // given
         val board = boardRepository.save(Fixture.createBoard(user = user, province = province))
         participantRepository.save(Participant(user, board))
@@ -320,7 +310,7 @@ class BoardServiceTest @Autowired constructor(
         }.errorCode shouldBe ParticipantErrorCode.WRITER_MUST_JOIN
     }
 
-    "먹팟 생성 시 시/도,군/구 값은 최초 1번만 디비에 값 저장 후 재사용" {
+    test("먹팟 생성 시 시/도,군/구 값은 최초 1번만 디비에 값 저장 후 재사용") {
         // when
         val boardId1 = boardService.saveBoard(userId, createRequest)
         val boardId2 = boardService.saveBoard(userId, createRequest)
@@ -336,7 +326,7 @@ class BoardServiceTest @Autowired constructor(
         findProvince shouldNotBe null
     }
 
-    "지역 조회정보는 최초1회 redis에 저장한다." {
+    test("지역 조회정보는 최초1회 redis에 저장한다.") {
         // when
         boardService.findAllRegions()
 
@@ -345,7 +335,7 @@ class BoardServiceTest @Autowired constructor(
         actual shouldNotBe null
     }
 
-    "먹팟 생성시 지역정보는 redis에서 삭제된다." {
+    test("먹팟 생성시 지역정보는 redis에서 삭제된다.") {
         // given
         boardService.findAllRegions()
 
@@ -355,5 +345,79 @@ class BoardServiceTest @Autowired constructor(
         // then
         val actual = redisService.getData(regionsRedisKey)
         actual shouldBe null
+    }
+
+    context("상세 조회 이전, 이후 아이디 테스트") {
+        var thirdBoardId: Long = 0
+        var secondBoardId: Long = 0
+        var firstBoardId: Long = 0
+
+        lateinit var province1: Province
+
+        beforeTest {
+            // given
+            province1 = provinceService.saveProvinceIfNot("city1", "province1")
+            val province2 = provinceService.saveProvinceIfNot("city1", "province2")
+            val province3 = provinceService.saveProvinceIfNot("city2", "province3")
+            thirdBoardId = boardService.saveBoard(
+                userId,
+                createRequest.apply {
+                    region_1depth_name = province3.city.name
+                    region_2depth_name = province3.name
+                }
+            )!!
+            secondBoardId = boardService.saveBoard(
+                userId,
+                createRequest.apply {
+                    region_1depth_name = province2.city.name
+                    region_2depth_name = province2.name
+                }
+            )!!
+            firstBoardId = boardService.saveBoard(
+                userId,
+                createRequest.apply {
+                    region_1depth_name = province1.city.name
+                    region_2depth_name = province1.name
+                }
+            )!!
+        }
+
+        test("cityId 조건이 포함되는 경우") {
+            // when
+            val actual = boardService.findBoardDetailAndVisit(
+                firstBoardId,
+                UserResponse.of(user),
+                RegionFilterRequest(
+                    cityId = province1.city.id
+                )
+            )
+            // then
+            actual.prevId shouldBe null
+            actual.nextId shouldBe secondBoardId
+        }
+
+        test("cityId, provinceId 조건이 포함되는 경우") {
+            // when
+            val actual = boardService.findBoardDetailAndVisit(
+                firstBoardId,
+                UserResponse.of(user),
+                RegionFilterRequest(cityId = province1.city.id, provinceId = province1.id)
+            )
+            // then
+            actual.prevId shouldBe null
+            actual.nextId shouldBe null
+        }
+
+        test("지역 필터 없는경우") {
+            // when
+            val actual = boardService.findBoardDetailAndVisit(
+                secondBoardId,
+                UserResponse.of(user),
+                RegionFilterRequest()
+            )
+            // then
+            actual.prevId shouldBe firstBoardId
+            actual.nextId shouldBe thirdBoardId
+        }
     }
 })

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
@@ -99,325 +99,343 @@ class BoardServiceTest @Autowired constructor(
         cityRepository.deleteAll()
     }
 
-    test("먹팟 생성 성공") {
-        // when
-        val boardId = boardService.saveBoard(userId, createRequest)
+    context("먹팟 생성 테스트") {
 
-        // then
-        val findBoard = boardRepository.findByIdOrNull(boardId)!!
-        val participant = participantRepository.findByBoard(findBoard)
-        val findCity = cityRepository.findByName(createRequest.region_1depth_name)
-        val findProvince = provinceRepository.findByName(createRequest.region_2depth_name)
+        test("생성 성공") {
+            // when
+            val boardId = boardService.saveBoard(userId, createRequest)
 
-        findBoard shouldNotBe null
-        findBoard.user.id shouldBe userId
-        findBoard.currentApply shouldBe 1
-        participant shouldNotBe null
-        findCity shouldNotBe null
-        findProvince shouldNotBe null
-    }
+            // then
+            val findBoard = boardRepository.findByIdOrNull(boardId)!!
+            val participant = participantRepository.findByBoard(findBoard)
+            val findCity = cityRepository.findByName(createRequest.region_1depth_name)
+            val findProvince = provinceRepository.findByName(createRequest.region_2depth_name)
 
-    test("자신의 글은 조회수가 증가하지 않는다.") {
-        // given
-        val boardId = boardService.saveBoard(userId, createRequest)!!
-        val loginUserInfo = UserResponse.of(user)
-
-        // when
-        boardService.findBoardDetailAndVisit(boardId, loginUserInfo, RegionFilterRequest())
-        boardService.findBoardDetailAndVisit(boardId, loginUserInfo, RegionFilterRequest())
-
-        // then
-        val findBoard = boardRepository.findByIdOrNull(boardId)!!
-        findBoard.views shouldBe 0
-    }
-
-    test("먹팟 상세 조회시 조회수가 증가한다.") {
-        // given
-        val boardId = boardService.saveBoard(userId, createRequest)!!
-        val otherUser = UserResponse.of(userRepository.save(Fixture.createUser()))
-
-        // when
-        boardService.findBoardDetailAndVisit(boardId, otherUser, RegionFilterRequest())
-
-        // then
-        val findBoard = boardRepository.findByIdOrNull(boardId)!!
-        findBoard.views shouldBe 1
-    }
-
-    test("비로그인 유저도 조회수가 증가한다.") {
-        // given
-        val boardId = boardService.saveBoard(userId, createRequest)!!
-        // when
-        boardService.findBoardDetailAndVisit(boardId, null, RegionFilterRequest())
-        // then
-        val findBoard = boardRepository.findByIdOrNull(boardId)!!
-        findBoard.views shouldBe 1
-    }
-
-    test("먹팟 수정 성공") {
-        // given
-        val boardId = boardService.saveBoard(userId, createRequest)!!
-        // when
-        boardService.updateBoardAndSendEmail(userId, boardId, updateRequest)
-        // then
-        val actual = boardRepository.findByIdOrNull(boardId)!!
-        val findProvince = provinceRepository.findByName(updateRequest.region_2depth_name)
-
-        actual.maxApply shouldBe updateRequest.maxApply
-        actual.minAge shouldBe updateRequest.minAge
-        actual.maxAge shouldBe updateRequest.maxAge
-        actual.location.locationName shouldBe updateRequest.locationName
-        actual.getX() shouldBe updateRequest.x
-        actual.getY() shouldBe updateRequest.y
-        actual.title shouldBe updateRequest.title
-        actual.content shouldBe updateRequest.content
-        actual.chatLink shouldBe updateRequest.chatLink
-        actual.province!!.id.shouldBe(findProvince!!.id)
-    }
-
-    test("자신의 글만 수정할 수 있다.") {
-        // given
-        val otherUserId = -1L
-        val boardId = boardService.saveBoard(userId, createRequest)!!
-        // when & then
-        shouldThrow<MuckPotException> {
-            boardService.updateBoardAndSendEmail(otherUserId, boardId, updateRequest)
-        }.errorCode shouldBe BoardErrorCode.BOARD_UNAUTHORIZED
-    }
-
-    test("먹팟 참가 신청 성공") {
-        // given
-        val boardId = boardService.saveBoard(userId, createRequest)!!
-        val applyUser = userRepository.save(
-            MuckPotUser(
-                null, "test1@naver.com", "pw", "nickname1",
-                Gender.MEN, 2000, JobGroupMain.DEVELOPMENT, "sub", "url"
-            )
-        )
-        val applyUserId = applyUser.id!!
-
-        // when
-        boardService.joinBoard(applyUserId, boardId)
-
-        // then
-        val findBoard = boardRepository.findByIdOrNull(boardId)!!
-        val participant = participantRepository.findByBoard(findBoard)
-        findBoard.currentApply shouldBe 2
-        participant shouldNotBe null
-    }
-
-    test("먹팟 중복 참가 신청 불가 검증") {
-        val boardId = boardService.saveBoard(userId, createRequest)!!
-        shouldThrow<MuckPotException> {
-            boardService.joinBoard(userId, boardId)
-        }.errorCode shouldBe ParticipantErrorCode.ALREADY_JOIN
-    }
-
-    test("먹팟 참가 동시성 테스트") {
-        // given
-        val boardId = boardService.saveBoard(userId, createRequest)!!
-        val applyUser = userRepository.save(
-            MuckPotUser(
-                null, "test1@naver.com", "pw", "nickname1",
-                Gender.MEN, 2000, JobGroupMain.DEVELOPMENT, "sub", "url"
-            )
-        )
-        val applyId = applyUser.id!!
-
-        // when
-        val successCount = AtomicLong()
-        ConcurrencyHelper.execute(
-            { boardService.joinBoard(applyId, boardId) },
-            successCount
-        )
-
-        // then
-        val findBoard = boardRepository.findByIdOrNull(boardId)!!
-        findBoard.currentApply shouldBe 2
-    }
-
-    test("먹팟 삭제 요청시 INACTIVE로 변경된다.") {
-        // given
-        val boardId = boardService.saveBoard(userId, createRequest)!!
-
-        // when
-        boardService.deleteBoardAndSendEmail(userId, boardId)
-
-        val findBoard = boardRepository.findByIdOrNull(boardId)
-        findBoard shouldBe null
-    }
-
-    test("자신의 글만 삭제할 수 있다.") {
-        // given
-        val otherUserId = -1L
-        val boardId = boardService.saveBoard(userId, createRequest)!!
-        // when & then
-        shouldThrow<MuckPotException> {
-            boardService.deleteBoardAndSendEmail(otherUserId, boardId)
-        }.errorCode shouldBe BoardErrorCode.BOARD_UNAUTHORIZED
-    }
-
-    test("글 삭제시 참여자 목록도 함께 삭제한다.") {
-        // given
-        val board = boardRepository.save(Fixture.createBoard(user = user, province = province))
-        // when
-        boardService.deleteBoardAndSendEmail(userId, board.id!!)
-        // then
-        val findBoard = participantRepository.findByBoard(board)
-        findBoard shouldHaveSize 0
-    }
-
-    test("먹팟 상태변경 성공") {
-        // given
-        val boardId = boardRepository.save(Fixture.createBoard(user = user, province = province)).id!!
-        // when
-        boardService.changeStatus(userId, boardId, MuckPotStatus.DONE)
-        // then
-        val actual = boardRepository.findByIdOrNull(boardId)!!
-        actual.status shouldBe MuckPotStatus.DONE
-    }
-
-    test("먹팟 참가 신청 취소 성공") {
-        // given
-        val applyUser = userRepository.save(Fixture.createUser())
-        val board = boardRepository.save(Fixture.createBoard(user = user, province = province))
-        participantRepository.save(Participant(applyUser, board))
-        // when
-        boardService.cancelJoinAndSendEmail(applyUser.id!!, board.id!!)
-        // then
-        val findParticipant = participantRepository.findByUserAndBoard(applyUser, board)
-        findParticipant shouldBe null
-        board.currentApply shouldBe 0
-    }
-
-    test("기존 참가 신청 내역 없으면 참가 신청 취소 불가") {
-        // given
-        val applyUser = userRepository.save(Fixture.createUser())
-        val board = boardRepository.save(Fixture.createBoard(user = user, province = province))
-        // when & then
-        shouldThrow<MuckPotException> {
-            boardService.cancelJoinAndSendEmail(applyUser.id!!, board.id!!)
-        }.errorCode shouldBe ParticipantErrorCode.PARTICIPANT_NOT_FOUND
-    }
-
-    test("먹팟 글 작성자는 참가 신청 취소할 수 없다.") {
-        // given
-        val board = boardRepository.save(Fixture.createBoard(user = user, province = province))
-        participantRepository.save(Participant(user, board))
-        // when & then
-        shouldThrow<MuckPotException> {
-            boardService.cancelJoinAndSendEmail(user.id!!, board.id!!)
-        }.errorCode shouldBe ParticipantErrorCode.WRITER_MUST_JOIN
-    }
-
-    test("먹팟 생성 시 시/도,구/군 값은 최초 1번만 디비에 값 저장 후 재사용") {
-        // when
-        val boardId1 = boardService.saveBoard(userId, createRequest)
-        val boardId2 = boardService.saveBoard(userId, createRequest)
-        // then
-        val findBoard1 = boardRepository.findByIdOrNull(boardId1)!!
-        val findBoard2 = boardRepository.findByIdOrNull(boardId2)!!
-        val findCity = cityRepository.findByName(createRequest.region_1depth_name)
-        val findProvince = provinceRepository.findByName(createRequest.region_2depth_name)
-
-        findBoard1 shouldNotBe null
-        findBoard1.province!!.id.shouldBe(findBoard2.province!!.id)
-        findCity shouldNotBe null
-        findProvince shouldNotBe null
-    }
-
-    test("지역 조회정보는 최초1회 redis에 저장한다.") {
-        // when
-        boardService.findAllRegions()
-
-        // then
-        val actual = redisService.getData(regionsRedisKey)
-        actual shouldNotBe null
-    }
-
-    test("먹팟 생성시 지역정보는 redis에서 삭제된다.") {
-        // given
-        boardService.findAllRegions()
-
-        // when
-        boardService.saveBoard(userId, createRequest)
-
-        // then
-        val actual = redisService.getData(regionsRedisKey)
-        actual shouldBe null
-    }
-
-    context("상세 조회 이전, 이후 아이디 테스트") {
-        var thirdBoardId: Long = 0
-        var secondBoardId: Long = 0
-        var firstBoardId: Long = 0
-
-        lateinit var province1: Province
-
-        beforeTest {
-            // given
-            province1 = provinceService.saveProvinceIfNot("city1", "province1")
-            val province2 = provinceService.saveProvinceIfNot("city1", "province2")
-            val province3 = provinceService.saveProvinceIfNot("city2", "province3")
-            thirdBoardId = boardService.saveBoard(
-                userId,
-                createRequest.apply {
-                    region_1depth_name = province3.city.name
-                    region_2depth_name = province3.name
-                }
-            )!!
-            secondBoardId = boardService.saveBoard(
-                userId,
-                createRequest.apply {
-                    region_1depth_name = province2.city.name
-                    region_2depth_name = province2.name
-                }
-            )!!
-            firstBoardId = boardService.saveBoard(
-                userId,
-                createRequest.apply {
-                    region_1depth_name = province1.city.name
-                    region_2depth_name = province1.name
-                }
-            )!!
+            findBoard shouldNotBe null
+            findBoard.user.id shouldBe userId
+            findBoard.currentApply shouldBe 1
+            participant shouldNotBe null
+            findCity shouldNotBe null
+            findProvince shouldNotBe null
         }
 
-        test("cityId 조건이 포함되는 경우") {
+        test("먹팟 생성 시 시/도,구/군 값은 최초 1번만 디비에 값 저장 후 재사용") {
             // when
-            val actual = boardService.findBoardDetailAndVisit(
-                firstBoardId,
-                UserResponse.of(user),
-                RegionFilterRequest(
-                    cityId = province1.city.id
+            val boardId1 = boardService.saveBoard(userId, createRequest)
+            val boardId2 = boardService.saveBoard(userId, createRequest)
+            // then
+            val findBoard1 = boardRepository.findByIdOrNull(boardId1)!!
+            val findBoard2 = boardRepository.findByIdOrNull(boardId2)!!
+            val findCity = cityRepository.findByName(createRequest.region_1depth_name)
+            val findProvince = provinceRepository.findByName(createRequest.region_2depth_name)
+
+            findBoard1 shouldNotBe null
+            findBoard1.province!!.id.shouldBe(findBoard2.province!!.id)
+            findCity shouldNotBe null
+            findProvince shouldNotBe null
+        }
+
+        test("먹팟 생성시 지역정보는 redis에서 삭제된다.") {
+            // given
+            boardService.findAllRegions()
+
+            // when
+            boardService.saveBoard(userId, createRequest)
+
+            // then
+            val actual = redisService.getData(regionsRedisKey)
+            actual shouldBe null
+        }
+    }
+
+    context("먹팟 상세 테스트") {
+
+        test("자신의 글은 조회수가 증가하지 않는다.") {
+            // given
+            val boardId = boardService.saveBoard(userId, createRequest)!!
+            val loginUserInfo = UserResponse.of(user)
+
+            // when
+            boardService.findBoardDetailAndVisit(boardId, loginUserInfo, RegionFilterRequest())
+            boardService.findBoardDetailAndVisit(boardId, loginUserInfo, RegionFilterRequest())
+
+            // then
+            val findBoard = boardRepository.findByIdOrNull(boardId)!!
+            findBoard.views shouldBe 0
+        }
+
+        test("다른 유저가 조회시 조회수가 증가한다.") {
+            // given
+            val boardId = boardService.saveBoard(userId, createRequest)!!
+            val otherUser = UserResponse.of(userRepository.save(Fixture.createUser()))
+
+            // when
+            boardService.findBoardDetailAndVisit(boardId, otherUser, RegionFilterRequest())
+
+            // then
+            val findBoard = boardRepository.findByIdOrNull(boardId)!!
+            findBoard.views shouldBe 1
+        }
+
+        test("비로그인 유저도 조회수가 증가한다.") {
+            // given
+            val boardId = boardService.saveBoard(userId, createRequest)!!
+            // when
+            boardService.findBoardDetailAndVisit(boardId, null, RegionFilterRequest())
+            // then
+            val findBoard = boardRepository.findByIdOrNull(boardId)!!
+            findBoard.views shouldBe 1
+        }
+
+        context("상세 조회 이전, 이후 아이디 테스트") {
+            var thirdBoardId: Long = 0
+            var secondBoardId: Long = 0
+            var firstBoardId: Long = 0
+
+            lateinit var province1: Province
+
+            beforeTest {
+                // given
+                province1 = provinceService.saveProvinceIfNot("city1", "province1")
+                val province2 = provinceService.saveProvinceIfNot("city1", "province2")
+                val province3 = provinceService.saveProvinceIfNot("city2", "province3")
+                thirdBoardId = boardService.saveBoard(
+                    userId,
+                    createRequest.apply {
+                        region_1depth_name = province3.city.name
+                        region_2depth_name = province3.name
+                    }
+                )!!
+                secondBoardId = boardService.saveBoard(
+                    userId,
+                    createRequest.apply {
+                        region_1depth_name = province2.city.name
+                        region_2depth_name = province2.name
+                    }
+                )!!
+                firstBoardId = boardService.saveBoard(
+                    userId,
+                    createRequest.apply {
+                        region_1depth_name = province1.city.name
+                        region_2depth_name = province1.name
+                    }
+                )!!
+            }
+
+            test("cityId 조건이 포함되는 경우") {
+                // when
+                val actual = boardService.findBoardDetailAndVisit(
+                    firstBoardId,
+                    UserResponse.of(user),
+                    RegionFilterRequest(
+                        cityId = province1.city.id
+                    )
+                )
+                // then
+                actual.prevId shouldBe null
+                actual.nextId shouldBe secondBoardId
+            }
+
+            test("cityId, provinceId 조건이 포함되는 경우") {
+                // when
+                val actual = boardService.findBoardDetailAndVisit(
+                    firstBoardId,
+                    UserResponse.of(user),
+                    RegionFilterRequest(cityId = province1.city.id, provinceId = province1.id)
+                )
+                // then
+                actual.prevId shouldBe null
+                actual.nextId shouldBe null
+            }
+
+            test("지역 필터 없는경우") {
+                // when
+                val actual = boardService.findBoardDetailAndVisit(
+                    secondBoardId,
+                    UserResponse.of(user),
+                    RegionFilterRequest()
+                )
+                // then
+                actual.prevId shouldBe firstBoardId
+                actual.nextId shouldBe thirdBoardId
+            }
+        }
+    }
+
+    context("먹팟 수정 테스트") {
+        test("수정 성공") {
+            // given
+            val boardId = boardService.saveBoard(userId, createRequest)!!
+            // when
+            boardService.updateBoardAndSendEmail(userId, boardId, updateRequest)
+            // then
+            val actual = boardRepository.findByIdOrNull(boardId)!!
+            val findProvince = provinceRepository.findByName(updateRequest.region_2depth_name)
+
+            actual.maxApply shouldBe updateRequest.maxApply
+            actual.minAge shouldBe updateRequest.minAge
+            actual.maxAge shouldBe updateRequest.maxAge
+            actual.location.locationName shouldBe updateRequest.locationName
+            actual.getX() shouldBe updateRequest.x
+            actual.getY() shouldBe updateRequest.y
+            actual.title shouldBe updateRequest.title
+            actual.content shouldBe updateRequest.content
+            actual.chatLink shouldBe updateRequest.chatLink
+            actual.province!!.id.shouldBe(findProvince!!.id)
+        }
+
+        test("자신의 글만 수정할 수 있다.") {
+            // given
+            val otherUserId = -1L
+            val boardId = boardService.saveBoard(userId, createRequest)!!
+            // when & then
+            shouldThrow<MuckPotException> {
+                boardService.updateBoardAndSendEmail(otherUserId, boardId, updateRequest)
+            }.errorCode shouldBe BoardErrorCode.BOARD_UNAUTHORIZED
+        }
+    }
+
+    context("먹팟 참가 테스트") {
+        test("참가 신청 성공") {
+            // given
+            val boardId = boardService.saveBoard(userId, createRequest)!!
+            val applyUser = userRepository.save(
+                MuckPotUser(
+                    null, "test1@naver.com", "pw", "nickname1",
+                    Gender.MEN, 2000, JobGroupMain.DEVELOPMENT, "sub", "url"
                 )
             )
+            val applyUserId = applyUser.id!!
+
+            // when
+            boardService.joinBoard(applyUserId, boardId)
+
             // then
-            actual.prevId shouldBe null
-            actual.nextId shouldBe secondBoardId
+            val findBoard = boardRepository.findByIdOrNull(boardId)!!
+            val participant = participantRepository.findByBoard(findBoard)
+            findBoard.currentApply shouldBe 2
+            participant shouldNotBe null
         }
 
-        test("cityId, provinceId 조건이 포함되는 경우") {
-            // when
-            val actual = boardService.findBoardDetailAndVisit(
-                firstBoardId,
-                UserResponse.of(user),
-                RegionFilterRequest(cityId = province1.city.id, provinceId = province1.id)
-            )
-            // then
-            actual.prevId shouldBe null
-            actual.nextId shouldBe null
+        test("먹팟 중복 참가 신청 불가 검증") {
+            val boardId = boardService.saveBoard(userId, createRequest)!!
+            shouldThrow<MuckPotException> {
+                boardService.joinBoard(userId, boardId)
+            }.errorCode shouldBe ParticipantErrorCode.ALREADY_JOIN
         }
 
-        test("지역 필터 없는경우") {
-            // when
-            val actual = boardService.findBoardDetailAndVisit(
-                secondBoardId,
-                UserResponse.of(user),
-                RegionFilterRequest()
+        test("먹팟 참가 동시성 테스트") {
+            // given
+            val boardId = boardService.saveBoard(userId, createRequest)!!
+            val applyUser = userRepository.save(
+                MuckPotUser(
+                    null, "test1@naver.com", "pw", "nickname1",
+                    Gender.MEN, 2000, JobGroupMain.DEVELOPMENT, "sub", "url"
+                )
             )
+            val applyId = applyUser.id!!
+
+            // when
+            val successCount = AtomicLong()
+            ConcurrencyHelper.execute(
+                { boardService.joinBoard(applyId, boardId) },
+                successCount
+            )
+
             // then
-            actual.prevId shouldBe firstBoardId
-            actual.nextId shouldBe thirdBoardId
+            val findBoard = boardRepository.findByIdOrNull(boardId)!!
+            findBoard.currentApply shouldBe 2
+        }
+    }
+
+    context("먹팟 삭제 테스트") {
+        test("먹팟 삭제 요청시 INACTIVE로 변경된다.") {
+            // given
+            val boardId = boardService.saveBoard(userId, createRequest)!!
+
+            // when
+            boardService.deleteBoardAndSendEmail(userId, boardId)
+
+            val findBoard = boardRepository.findByIdOrNull(boardId)
+            findBoard shouldBe null
+        }
+
+        test("자신의 글만 삭제할 수 있다.") {
+            // given
+            val otherUserId = -1L
+            val boardId = boardService.saveBoard(userId, createRequest)!!
+            // when & then
+            shouldThrow<MuckPotException> {
+                boardService.deleteBoardAndSendEmail(otherUserId, boardId)
+            }.errorCode shouldBe BoardErrorCode.BOARD_UNAUTHORIZED
+        }
+
+        test("글 삭제시 참여자 목록도 함께 삭제한다.") {
+            // given
+            val board = boardRepository.save(Fixture.createBoard(user = user, province = province))
+            // when
+            boardService.deleteBoardAndSendEmail(userId, board.id!!)
+            // then
+            val findBoard = participantRepository.findByBoard(board)
+            findBoard shouldHaveSize 0
+        }
+    }
+
+    context("먹팟 상태 변경 테스트") {
+        test("먹팟 상태변경 성공") {
+            // given
+            val boardId = boardRepository.save(Fixture.createBoard(user = user, province = province)).id!!
+            // when
+            boardService.changeStatus(userId, boardId, MuckPotStatus.DONE)
+            // then
+            val actual = boardRepository.findByIdOrNull(boardId)!!
+            actual.status shouldBe MuckPotStatus.DONE
+        }
+    }
+
+    context("참가 신청 취소 테스트") {
+        test("참가 신청 취소 성공") {
+            // given
+            val applyUser = userRepository.save(Fixture.createUser())
+            val board = boardRepository.save(Fixture.createBoard(user = user, province = province))
+            participantRepository.save(Participant(applyUser, board))
+            // when
+            boardService.cancelJoinAndSendEmail(applyUser.id!!, board.id!!)
+            // then
+            val findParticipant = participantRepository.findByUserAndBoard(applyUser, board)
+            findParticipant shouldBe null
+            board.currentApply shouldBe 0
+        }
+
+        test("기존 참가 신청 내역 없으면 참가 신청 취소 불가") {
+            // given
+            val applyUser = userRepository.save(Fixture.createUser())
+            val board = boardRepository.save(Fixture.createBoard(user = user, province = province))
+            // when & then
+            shouldThrow<MuckPotException> {
+                boardService.cancelJoinAndSendEmail(applyUser.id!!, board.id!!)
+            }.errorCode shouldBe ParticipantErrorCode.PARTICIPANT_NOT_FOUND
+        }
+
+        test("먹팟 글 작성자는 참가 신청 취소할 수 없다.") {
+            // given
+            val board = boardRepository.save(Fixture.createBoard(user = user, province = province))
+            participantRepository.save(Participant(user, board))
+            // when & then
+            shouldThrow<MuckPotException> {
+                boardService.cancelJoinAndSendEmail(user.id!!, board.id!!)
+            }.errorCode shouldBe ParticipantErrorCode.WRITER_MUST_JOIN
+        }
+    }
+
+    context("등록된 모든 지역정보 조회 테스트") {
+        test("지역 조회정보는 최초1회 redis에 저장한다.") {
+            // when
+            boardService.findAllRegions()
+
+            // then
+            val actual = redisService.getData(regionsRedisKey)
+            actual shouldNotBe null
         }
     }
 })

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
@@ -310,7 +310,7 @@ class BoardServiceTest @Autowired constructor(
         }.errorCode shouldBe ParticipantErrorCode.WRITER_MUST_JOIN
     }
 
-    test("먹팟 생성 시 시/도,군/구 값은 최초 1번만 디비에 값 저장 후 재사용") {
+    test("먹팟 생성 시 시/도,구/군 값은 최초 1번만 디비에 값 저장 후 재사용") {
         // when
         val boardId1 = boardService.saveBoard(userId, createRequest)
         val boardId2 = boardService.saveBoard(userId, createRequest)

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/repository/BoardQuerydslRepository.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/repository/BoardQuerydslRepository.kt
@@ -31,17 +31,19 @@ class BoardQuerydslRepository(
             .fetch()
     }
 
-    fun findPrevId(boardId: Long): Long? {
+    fun findPrevId(boardId: Long, cityId: Long? = null, provinceId: Long? = null): Long? {
         return queryFactory.from(board)
+            .innerJoin(board.province, province)
             .select(board.id.min())
-            .where(board.id.gt(boardId))
+            .where(board.id.gt(boardId), cityIdEqBoard(cityId), provinceIdEqBoard(provinceId))
             .fetchOne()
     }
 
-    fun findNextId(boardId: Long): Long? {
+    fun findNextId(boardId: Long, cityId: Long? = null, provinceId: Long? = null): Long? {
         return queryFactory.from(board)
+            .innerJoin(board.province, province)
             .select(board.id.max())
-            .where(board.id.lt(boardId))
+            .where(board.id.lt(boardId), cityIdEqBoard(cityId), provinceIdEqBoard(provinceId))
             .fetchOne()
     }
 
@@ -78,6 +80,18 @@ class BoardQuerydslRepository(
     private fun lessThanLastId(lastId: Long?): BooleanExpression? {
         return lastId?.let {
             board.id.lt(it)
+        }
+    }
+
+    private fun cityIdEqBoard(cityId: Long?): BooleanExpression? {
+        return cityId?.let {
+            board.province.city.id.eq(cityId)
+        }
+    }
+
+    private fun provinceIdEqBoard(provinceId: Long?): BooleanExpression? {
+        return provinceId?.let {
+            board.province.id.eq(provinceId)
         }
     }
 }


### PR DESCRIPTION
## 개요
- close #116 

## 작업사항
- 먹팟 상세 조회시 지역정보(cityId, provinceId)를 쿼리파라미터 추가
  - provinceId는 있지만, cityId가 없는 경우는 예외처리 하였습니다.