### PR TITLE
fix: 120 참여 취소시 상태변경

### DIFF
--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
@@ -109,10 +109,6 @@ class Board(
         this.views++
     }
 
-    fun expired(): Boolean {
-        return (this.status == IN_PROGRESS && this.meetingTime.isBefore(LocalDateTime.now()))
-    }
-
     fun getX(): Double {
         return this.location.locationPoint.x
     }
@@ -135,6 +131,8 @@ class Board(
     }
 
     fun cancelJoin() {
+        require(meetingTime > LocalDateTime.now()) { "이미 마감된 먹팟입니다." }
+        this.status = IN_PROGRESS
         this.currentApply--
     }
 

--- a/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/entity/BoardTest.kt
+++ b/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/entity/BoardTest.kt
@@ -96,5 +96,15 @@ class BoardTest : FunSpec({
 
             board.status shouldBe MuckPotStatus.IN_PROGRESS
         }
+
+        test("먹팟 취소시 상태 IN_PROGRESS 변경 성공") {
+            // given
+            val board = Fixture.createBoard(maxApply = 2, currentApply = 2, status = MuckPotStatus.DONE)
+            // when
+            board.cancelJoin()
+            // then
+            board.currentApply shouldBe 1
+            board.status shouldBe MuckPotStatus.IN_PROGRESS
+        }
     }
 })


### PR DESCRIPTION
## 개요
- close #120 
- 참여 취소시 상태 변경
- [노션 링크](https://www.notion.so/yapp-workspace/1d0d68f0896e4399b63cc509a6f7443c?pvs=4)

## 작업사항
- 먹팟 참여 취소 시 상태 변경 추가

## 변경로직
- 먹팟 시간이 지난 경우에는 취소하지 못하게 유효성 검사 추가하였습니다.
- 참여 취소 시 항상 IN_PROGRESS로 변경하도록 변경하였습니다.