### PR TITLE
feat: 126 jacoco+sonarcloud 연동

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK 11
@@ -18,7 +17,17 @@ jobs:
       with:
         java-version: '11'
         distribution: 'temurin'
-
+    - name: Cache SonarCloud packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.sonar/cache
+        key: ${{ runner.os }}-sonar
+        restore-keys: ${{ runner.os }}-sonar
+    - name: test and analyze
+      run: ./gradlew test sonar --info --stacktrace --no-daemon
+      env:
+        GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     - name: Gradle Clean & Build
       run: ./gradlew clean build
 


### PR DESCRIPTION
## 개요
- close #126 

## 작업사항
- jacoco를 활용해 테스트 커버리지를 측정하고 
해당 측정 값을 소나클라우드로 전송해 소나클라우드 정적 검사와 jacoco 테스트 커버리지 측정 값을 함께 노출
- jacoco 및 sonar cloud 연동
- xml 파일로 jacoco 측정값 저장 후 sonar cloud에 전송

## 변경로직

[ref](https://cofls6581.tistory.com/275#comment15937661)