### PR TITLE
refactor: 131 먹팟 상세 년도 추가, 수정 조회 API 추가

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/constants/SwaggerConstant.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/constants/SwaggerConstant.kt
@@ -85,27 +85,30 @@ const val MUCKPOT_FIND_BY_ID = """
 {
   "status": 200,
   "result": {
-    "boardId": 114,
-    "title": "같이 밥묵으실분",
-    "content": "내용 입니다.",
-    "chatLink": "https://open.kakao.com/o/gSIkvvHc",
-    "status": "모집중",
-    "meetingDate": "07월 21일 (금)",
-    "meetingTime": "오후 01:00",
-    "createDate": "2023년 06월 11일",
-    "maxApply": 5,
+    "boardId": 31,
+    "prevId": null,
+    "nextId": 14,
+    "title": "개성주악 먹어여",
+    "content": "개성주악 맛있어요",
+    "chatLink": "https://open.kakao.com/o/s0U23Rsf",
+    "status": "모집마감",
+    "meetingDate": "2023년 07월 14일 (금)",
+    "meetingTime": "오후 12:30",
+    "createDate": "2023년 07월 14일",
+    "maxApply": 2,
     "currentApply": 1,
-    "minAge": 20,
-    "maxAge": 100,
-    "locationName": "서울 성북구 안암동5가 104-30 캐치카페 안암",
-    "x": 127.02970799701643,
-    "y": 37.58392327180857,
-    "locationDetail": "6층",
-    "views": 1,
+    "minAge": 21,
+    "maxAge": 25,
+    "locationName": "경기 파주시 탄현면 갈현리 797-1 연리희재",
+    "x": 126.713351951771,
+    "y": 37.7684106528357,
+    "locationDetail": "",
+    "views": 208,
+    "userAge": null,
     "participants": [
       {
-        "userId": 128,
-        "nickName": "nickname2",
+        "userId": 21,
+        "nickName": "건빵",
         "jobGroupMain": "개발",
         "writer": true
       }
@@ -150,6 +153,29 @@ const val MUCKPOT_REGIONS = """
         ]
       }
     ]
+  }
+}
+"""
+
+const val MUCKPOT_FIND_BY_ID_FOR_UPDATE = """
+{
+  "status": 200,
+  "result": {
+    "boardId": 31,
+    "title": "개성주악 먹어여",
+    "content": "개성주악 맛있어요",
+    "chatLink": "https://open.kakao.com/o/s0U23Rsf",
+    "meetingDate": "2023년 07월 14일 (금)",
+    "meetingTime": "오후 12:30",
+    "createDate": "2023년 07월 14일",
+    "maxApply": 2,
+    "minAge": 21,
+    "maxAge": 25,
+    "locationName": "경기 파주시 탄현면 갈현리 797-1 연리희재",
+    "x": 126.713351951771,
+    "y": 37.7684106528357,
+    "locationDetail": "",
+    "userAge": null
   }
 }
 """

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/BoardController.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/BoardController.kt
@@ -3,6 +3,7 @@ package com.yapp.muckpot.domains.board.controller
 import com.yapp.muckpot.common.ResponseDto
 import com.yapp.muckpot.common.constants.MUCKPOT_FIND_ALL
 import com.yapp.muckpot.common.constants.MUCKPOT_FIND_BY_ID
+import com.yapp.muckpot.common.constants.MUCKPOT_FIND_BY_ID_FOR_UPDATE
 import com.yapp.muckpot.common.constants.MUCKPOT_JOIN_RESPONSE
 import com.yapp.muckpot.common.constants.MUCKPOT_REGIONS
 import com.yapp.muckpot.common.constants.MUCKPOT_SAVE_RESPONSE
@@ -227,5 +228,30 @@ class BoardController(
     @GetMapping("/v1/boards/regions")
     fun findAllRegions(): ResponseEntity<ResponseDto> {
         return ResponseEntityUtil.ok(boardService.findAllRegions())
+    }
+
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                code = 200,
+                examples = Example(
+                    ExampleProperty(
+                        value = MUCKPOT_FIND_BY_ID_FOR_UPDATE,
+                        mediaType = MediaType.APPLICATION_JSON_VALUE
+                    )
+                ),
+                message = "성공"
+            )
+        ]
+    )
+    @ApiOperation(value = "먹팟 수정 정보 조회")
+    @GetMapping("/v1/boards/{boardId}/update")
+    fun findUpdateBoardDetail(@PathVariable boardId: Long): ResponseEntity<ResponseDto> {
+        return ResponseEntityUtil.ok(
+            boardService.findUpdateBoardDetail(
+                boardId,
+                SecurityContextHolderUtil.getCredentialOrNull()
+            )
+        )
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotDetailResponse.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotDetailResponse.kt
@@ -1,8 +1,8 @@
 package com.yapp.muckpot.domains.board.controller.dto
 
 import com.yapp.muckpot.common.TimeUtil
-import com.yapp.muckpot.common.constants.KR_MM_DD_E
 import com.yapp.muckpot.common.constants.KR_YYYY_MM_DD
+import com.yapp.muckpot.common.constants.KR_YYYY_MM_DD_E
 import com.yapp.muckpot.common.constants.a_hhmm
 import com.yapp.muckpot.domains.board.dto.ParticipantReadResponse
 import com.yapp.muckpot.domains.board.entity.Board
@@ -71,7 +71,7 @@ data class MuckpotDetailResponse(
                 content = board.content,
                 chatLink = board.chatLink,
                 status = board.status.korNm,
-                meetingDate = TimeUtil.localeKoreanFormatting(board.meetingTime, KR_MM_DD_E),
+                meetingDate = TimeUtil.localeKoreanFormatting(board.meetingTime, KR_YYYY_MM_DD_E),
                 meetingTime = TimeUtil.localeKoreanFormatting(board.meetingTime, a_hhmm),
                 createDate = TimeUtil.localeKoreanFormatting(board.createdAt, KR_YYYY_MM_DD),
                 maxApply = board.maxApply,

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotUpdateDetailResponse.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotUpdateDetailResponse.kt
@@ -1,0 +1,59 @@
+package com.yapp.muckpot.domains.board.controller.dto
+
+import com.yapp.muckpot.common.TimeUtil
+import com.yapp.muckpot.common.constants.KR_YYYY_MM_DD
+import com.yapp.muckpot.common.constants.KR_YYYY_MM_DD_E
+import com.yapp.muckpot.common.constants.a_hhmm
+import com.yapp.muckpot.domains.board.entity.Board
+
+data class MuckpotUpdateDetailResponse(
+    val boardId: Long,
+    val title: String,
+    val content: String? = null,
+    val chatLink: String,
+    val meetingDate: String,
+    val meetingTime: String,
+    val createDate: String,
+    val maxApply: Int,
+    var minAge: Int? = null,
+    var maxAge: Int? = null,
+    val locationName: String,
+    val x: Double,
+    val y: Double,
+    val locationDetail: String? = null,
+    val userAge: Int?
+) {
+    private fun changeIsNotAgeLimit() {
+        this.minAge = null
+        this.maxAge = null
+    }
+
+    companion object {
+        fun of(
+            board: Board,
+            userAge: Int? = null
+        ): MuckpotUpdateDetailResponse {
+            val response = MuckpotUpdateDetailResponse(
+                boardId = board.id ?: 0,
+                title = board.title,
+                content = board.content,
+                chatLink = board.chatLink,
+                meetingDate = TimeUtil.localeKoreanFormatting(board.meetingTime, KR_YYYY_MM_DD_E),
+                meetingTime = TimeUtil.localeKoreanFormatting(board.meetingTime, a_hhmm),
+                createDate = TimeUtil.localeKoreanFormatting(board.createdAt, KR_YYYY_MM_DD),
+                maxApply = board.maxApply,
+                minAge = board.minAge,
+                maxAge = board.maxAge,
+                locationName = board.location.locationName,
+                x = board.getX(),
+                y = board.getY(),
+                locationDetail = board.locationDetail,
+                userAge = userAge
+            )
+            if (board.isNotAgeLimit()) {
+                response.changeIsNotAgeLimit()
+            }
+            return response
+        }
+    }
+}

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
@@ -7,6 +7,7 @@ import com.yapp.muckpot.domains.board.controller.dto.AllMuckpotGetRequest
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotCreateRequest
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotDetailResponse
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotReadResponse
+import com.yapp.muckpot.domains.board.controller.dto.MuckpotUpdateDetailResponse
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotUpdateRequest
 import com.yapp.muckpot.domains.board.controller.dto.RegionFilterRequest
 import com.yapp.muckpot.domains.board.entity.Participant
@@ -195,5 +196,18 @@ class BoardService(
                 muckpotCityResponses.add(RegionConverter.convertToCityResponse(city, provinces))
             }
         return RegionResponse(muckpotCityResponses)
+    }
+
+    @Transactional(readOnly = true)
+    fun findUpdateBoardDetail(boardId: Long, loginUserInfo: UserResponse?): MuckpotUpdateDetailResponse {
+        boardRepository.findByIdOrNull(boardId)?.let { board ->
+            val userAge: Int? = loginUserInfo?.let { userRepository.findByIdOrNull(it.userId)?.getAge() }
+            return MuckpotUpdateDetailResponse.of(
+                board = board,
+                userAge = userAge
+            )
+        } ?: run {
+            throw MuckPotException(BoardErrorCode.BOARD_NOT_FOUND)
+        }
     }
 }

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/common/TimeUtilTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/common/TimeUtilTest.kt
@@ -3,6 +3,7 @@ package com.yapp.muckpot.common
 import com.yapp.muckpot.common.constants.A_DAY_AGO
 import com.yapp.muckpot.common.constants.KR_MM_DD_E
 import com.yapp.muckpot.common.constants.KR_YYYY_MM_DD
+import com.yapp.muckpot.common.constants.KR_YYYY_MM_DD_E
 import com.yapp.muckpot.common.constants.N_HOURS_AGO
 import com.yapp.muckpot.common.constants.N_MINUTES_AGO
 import com.yapp.muckpot.common.constants.TODAY_KR
@@ -104,6 +105,13 @@ class TimeUtilTest : FunSpec({
         val localDateTime = LocalDateTime.of(2020, 1, 2, 12, 0)
         // when & then
         TimeUtil.localeKoreanFormatting(localDateTime, KR_MM_DD_E) shouldBe "01월 02일 (목)"
+    }
+
+    test("KR_YYYY_MM_DD_E 포맷 테스트") {
+        // given
+        val localDateTime = LocalDateTime.of(2020, 1, 2, 12, 0)
+        // when & then
+        TimeUtil.localeKoreanFormatting(localDateTime, KR_YYYY_MM_DD_E) shouldBe "2020년 01월 02일 (목)"
     }
 
     test("KR_YYYY_MM_DD 포맷 테스트") {

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceMockTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceMockTest.kt
@@ -108,10 +108,10 @@ class BoardServiceMockTest @Autowired constructor(
 
         test("먹팟 상세조회 성공") {
             // when
-            val actual = boardService.findBoardDetailAndVisit(1, loginUser, RegionFilterRequest())
+            val actual = boardService.findBoardDetailAndVisit(board.id!!, loginUser, RegionFilterRequest())
 
             // then
-            actual.meetingDate shouldBe "12월 25일 (토)"
+            actual.meetingDate shouldBe "2100년 12월 25일 (토)"
             actual.meetingTime shouldBe "오후 12:20"
             actual.createDate shouldBe "2100년 12월 23일"
             actual.status shouldBe IN_PROGRESS.korNm

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
@@ -438,4 +438,21 @@ class BoardServiceTest @Autowired constructor(
             actual shouldNotBe null
         }
     }
+
+    context("먹팟 수정 정보 조회 테스트") {
+
+        test("수정을 위한 상세 데이터 조회 성공") {
+            // given
+            val boardId = boardService.saveBoard(userId, createRequest)!!
+            val loginUserInfo = UserResponse.of(user)
+
+            // when
+            val actual = boardService.findUpdateBoardDetail(boardId, loginUserInfo)
+
+            // then
+            actual.userAge shouldBe user.getAge()
+            actual.title shouldBe createRequest.title
+            actual.content shouldBe createRequest.content
+        }
+    }
 })

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/constants/RegexPatternConst.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/constants/RegexPatternConst.kt
@@ -10,5 +10,6 @@ const val YYYYMMDD = "yyyy-MM-dd"
 const val HHmm = "HH:mm"
 
 const val KR_MM_DD_E = "MM월 dd일 (E)"
+const val KR_YYYY_MM_DD_E = "YYYY년 MM월 dd일 (E)"
 const val KR_YYYY_MM_DD = "YYYY년 MM월 dd일"
 const val a_hhmm = "a hh:mm"

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/repository/ParticipantQuerydslRepository.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/repository/ParticipantQuerydslRepository.kt
@@ -24,6 +24,7 @@ class ParticipantQuerydslRepository(
             )
         )
             .from(participant)
+            .innerJoin(participant.user, muckPotUser)
             .where(participant.board.id.`in`(boardIds))
             .orderBy(participant.createdAt.asc())
             .fetch()


### PR DESCRIPTION
## 개요
- close #131

## 작업사항
- 먹팟 수정시 상세 조회 API를 사용하게되면 조회수가 증가되기 때문에 별도 조회 API 추가

## 변경로직
- 먹팟 상세 조회시 YYYY 년도 누락되어 추가