### PR TITLE
refactor:137 먹팟 수정, 참여상태 변경 유효성검사 추가, 스케줄러 캐시 삭제 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
 
-    - name: Gradle Clean & Build
-      run: ./gradlew clean build
-
     - name: Cache SonarCloud packages
       uses: actions/cache@v3
       with:
@@ -35,6 +32,9 @@ jobs:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
+
+    - name: Gradle Clean & Build
+      run: ./gradlew clean build
 
     - name: Gradle Sonar
       run: ./gradlew sonar -Dorg.gradle.jvmargs="-Xmx2g" --stacktrace --no-daemon

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardScheduler.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardScheduler.kt
@@ -1,7 +1,10 @@
 package com.yapp.muckpot.domains.board.service
 
 import com.yapp.muckpot.domains.board.repository.BoardQuerydslRepository
+import com.yapp.muckpot.redis.constants.ALL_KEY
+import com.yapp.muckpot.redis.constants.REGIONS_CACHE_NAME
 import mu.KLogging
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -12,6 +15,7 @@ class BoardScheduler(
 ) {
     private val log = KLogging().logger
 
+    @CacheEvict(value = [REGIONS_CACHE_NAME], key = ALL_KEY)
     @Scheduled(cron = "0 $UPDATE_MINUTES $UPDATE_HOURS * * *")
     @Transactional
     fun updateDoneBoard() {

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
@@ -98,6 +98,9 @@ class BoardService(
             if (board.isNotMyBoard(userId)) {
                 throw MuckPotException(BoardErrorCode.BOARD_UNAUTHORIZED)
             }
+            if (board.isDone()) {
+                throw MuckPotException(BoardErrorCode.DONE_BOARD_NOT_UPDATE)
+            }
             // Update 이전에 수행되어야 함.
             val mailTitle = EmailTemplate.BOARD_UPDATE_EMAIL.formatSubject(board.title)
             val mailBody = EmailTemplate.BOARD_UPDATE_EMAIL.formatBody(

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
@@ -293,6 +293,16 @@ class BoardServiceTest @Autowired constructor(
                 boardService.updateBoardAndSendEmail(otherUserId, boardId, updateRequest)
             }.errorCode shouldBe BoardErrorCode.BOARD_UNAUTHORIZED
         }
+
+        test("만료 상태의 먹팟은 수정할 수 없다.") {
+            // given
+            val boardId = boardService.saveBoard(userId, createRequest)!!
+            boardService.changeStatus(userId, boardId, MuckPotStatus.DONE)
+            // when & then
+            shouldThrow<MuckPotException> {
+                boardService.updateBoardAndSendEmail(userId, boardId, updateRequest)
+            }.errorCode shouldBe BoardErrorCode.DONE_BOARD_NOT_UPDATE
+        }
     }
 
     context("먹팟 참가 테스트") {

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
@@ -124,19 +124,27 @@ class Board(
     fun changeStatus(changeStatus: MuckPotStatus) {
         require(
             (this.status == IN_PROGRESS && changeStatus == DONE) ||
-                ((this.status == DONE && changeStatus == IN_PROGRESS) && currentApply < maxApply)
+                (this.status == DONE && changeStatus == IN_PROGRESS)
         ) { "변경 가능한 상태가 아닙니다." }
-
+        validateToday()
         this.status = changeStatus
     }
 
     fun cancelJoin() {
-        require(meetingTime > LocalDateTime.now()) { "이미 마감된 먹팟입니다." }
+        validateToday()
         this.status = IN_PROGRESS
         this.currentApply--
     }
 
     fun isNotAgeLimit(): Boolean {
         return (this.minAge == AGE_MIN && this.maxAge == AGE_MAX)
+    }
+
+    fun isDone(): Boolean {
+        return this.status == DONE
+    }
+
+    private fun validateToday() {
+        require(meetingTime > LocalDateTime.now()) { "이미 마감된 먹팟입니다." }
     }
 }

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/exception/BoardErrorCode.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/exception/BoardErrorCode.kt
@@ -10,7 +10,8 @@ enum class BoardErrorCode(
 ) : BaseErrorCode {
     BOARD_NOT_FOUND(StatusCode.BAD_REQUEST.code, "먹팟 정보를 찾을 수 없습니다."),
     MAX_APPLY_UPDATE_FAIL(StatusCode.BAD_REQUEST.code, "현재 참여인원 이상으로만 설정 가능합니다."),
-    BOARD_UNAUTHORIZED(StatusCode.UNAUTHORIZED.code, "내가 작성한 글에만 접근할 수 있습니다.");
+    BOARD_UNAUTHORIZED(StatusCode.UNAUTHORIZED.code, "내가 작성한 글에만 접근할 수 있습니다."),
+    DONE_BOARD_NOT_UPDATE(StatusCode.UNAUTHORIZED.code, "모집마감 먹팟은 변경할 수 없습니다.");
 
     override fun toResponseDto(): ResponseDto {
         return ResponseDto(this.status, this.reason, null)

--- a/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/entity/BoardTest.kt
+++ b/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/entity/BoardTest.kt
@@ -72,15 +72,16 @@ class BoardTest : FunSpec({
             }.message shouldBe "변경 가능한 상태가 아닙니다."
         }
 
-        test("모집인원이 마감된 경우에는 IN_PROGRESS 로 변경할 수 없다.") {
+        test("모집인원이 마감된 경우에도 IN_PROGRESS 로 변경할 수 있다.") {
             val board = Fixture.createBoard(
                 status = MuckPotStatus.DONE,
                 currentApply = 3,
                 maxApply = 3
             )
-            shouldThrow<IllegalArgumentException> {
-                board.changeStatus(MuckPotStatus.IN_PROGRESS)
-            }.message shouldBe "변경 가능한 상태가 아닙니다."
+            // when
+            board.changeStatus(MuckPotStatus.IN_PROGRESS)
+            // then
+            board.status shouldBe MuckPotStatus.IN_PROGRESS
         }
 
         test("IN_PROGRESS -> DONE 변경 성공") {
@@ -95,6 +96,15 @@ class BoardTest : FunSpec({
             board.changeStatus(MuckPotStatus.IN_PROGRESS)
 
             board.status shouldBe MuckPotStatus.IN_PROGRESS
+        }
+
+        test("현재 시간 이전의 먹팟은 상태를 변경할 수 없다.") {
+            val board = Fixture.createBoard(status = MuckPotStatus.DONE)
+                .apply { meetingTime = LocalDateTime.now().minusMinutes(30) }
+
+            shouldThrow<IllegalArgumentException> {
+                board.changeStatus(MuckPotStatus.IN_PROGRESS)
+            }.message shouldBe "이미 마감된 먹팟입니다."
         }
 
         test("먹팟 취소시 상태 IN_PROGRESS 변경 성공") {


### PR DESCRIPTION
## 개요
- close #137 

## 작업사항
- 먹팟 수정
    -  만료된 먹팟은 수정 불가능.

- 먹팟 상태 변경
  - 유효성 검사 추가
    - 현재시간 이전 먹팟 상태변경 불가능 유효성 추가

  - 기존 유효성 검사로직 삭제
    - 모집 인원이 마감된 경우에도 변경 가능하도록 기존 유효성 검사로직 삭제
    - 수정을 위해서 변경가능하도록 허용

- 캐시삭제 추가
  - 스케줄러에서 먹팟 상태가 변경되기 때문에 캐시 삭제