### PR TITLE
bug: 139 캐시 삭제로직 추가

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/ProvinceService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/ProvinceService.kt
@@ -4,6 +4,10 @@ import com.yapp.muckpot.domains.board.entity.City
 import com.yapp.muckpot.domains.board.entity.Province
 import com.yapp.muckpot.domains.board.repository.CityRepository
 import com.yapp.muckpot.domains.board.repository.ProvinceRepository
+import com.yapp.muckpot.redis.constants.ALL_KEY
+import com.yapp.muckpot.redis.constants.REGIONS_CACHE_NAME
+import mu.KLogging
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -12,9 +16,16 @@ class ProvinceService(
     private val cityRepository: CityRepository,
     private val provinceRepository: ProvinceRepository
 ) {
+    private val log = KLogging().logger
+
     @Transactional
     fun saveProvinceIfNot(cityName: String, provinceName: String): Province {
         val city = cityRepository.findByName(cityName) ?: cityRepository.save(City(cityName))
         return provinceRepository.findByName(provinceName) ?: provinceRepository.save(Province(provinceName, city))
+    }
+
+    @CacheEvict(value = [REGIONS_CACHE_NAME], key = ALL_KEY)
+    fun clearRegionsAll() {
+        log.info { "지역정보 캐시 삭제" }
     }
 }

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
@@ -100,7 +100,7 @@ class Board(
         require(currentApply < maxApply) { "참여 모집이 마감되었습니다." }
         require(status == IN_PROGRESS) { "참여 모집이 마감되었습니다." }
         this.currentApply++
-        if (currentApply == maxApply) {
+        if (isFull()) {
             this.status = DONE
         }
     }
@@ -142,6 +142,10 @@ class Board(
 
     fun isDone(): Boolean {
         return this.status == DONE
+    }
+
+    fun isFull(): Boolean {
+        return this.currentApply == this.maxApply
     }
 
     private fun validateToday() {

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/user/enums/MuckPotStatus.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/user/enums/MuckPotStatus.kt
@@ -3,5 +3,5 @@ package com.yapp.muckpot.domains.user.enums
 enum class MuckPotStatus(
     val korNm: String
 ) {
-    IN_PROGRESS("모집중"), DONE("모집마감")
+    IN_PROGRESS("모집중"), DONE("모집종료")
 }

--- a/muckpot-domain/src/testFixtures/kotlin/Fixture.kt
+++ b/muckpot-domain/src/testFixtures/kotlin/Fixture.kt
@@ -17,7 +17,7 @@ object Fixture {
         id: Long? = null,
         email: String = UUID.randomUUID().toString().substring(0, 5) + "@naver.com",
         password: String = "abcd1234",
-        nickName: String = UUID.randomUUID().toString(),
+        nickName: String = UUID.randomUUID().toString().substring(0, 10),
         gender: Gender = Gender.MEN,
         yearOfBirth: Int = 2000,
         mainCategory: JobGroupMain = JobGroupMain.DEVELOPMENT,


### PR DESCRIPTION
## 개요
- close #139 

## 작업사항
- 먹팟 참여, 취소 시 상태가 변경되는 경우가 존재.
  - 이 경우 카테고리 상태가 변경되기 때문에 캐시 삭제로직 추가

## 변경로직
- Fixture 코드 수정
  - 제약조건에 맞추어 수정 -> user.nickname은 10자까지만 저장 가능
- DONE 한글명 변경
  - 1.0 피그마에 맞추어 모집마감 -> 모집 종료로 변경하였습니다.