### PR TITLE
fix: 148 provinceName으로 조회시 list가 될 수 있어서 대응

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/ProvinceService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/ProvinceService.kt
@@ -21,8 +21,7 @@ class ProvinceService(
     @Transactional
     fun saveProvinceIfNot(cityName: String, provinceName: String): Province {
         val city = cityRepository.findByName(cityName) ?: cityRepository.save(City(cityName))
-        val provinces = provinceRepository.findByName(provinceName)
-        provinces.forEach { province ->
+        provinceRepository.findByName(provinceName).forEach { province ->
             if (province.city.name == cityName) {
                 return province
             }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/ProvinceService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/ProvinceService.kt
@@ -21,9 +21,9 @@ class ProvinceService(
     @Transactional
     fun saveProvinceIfNot(cityName: String, provinceName: String): Province {
         val city = cityRepository.findByName(cityName) ?: cityRepository.save(City(cityName))
-        val province = provinceRepository.findByName(provinceName)
-        province?.let {
-            if (it.city.name == cityName) {
+        val provinces = provinceRepository.findByName(provinceName)
+        provinces.forEach { province ->
+            if (province.city.name == cityName) {
                 return province
             }
         }

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
@@ -281,7 +281,7 @@ class BoardServiceTest @Autowired constructor(
             actual.title shouldBe updateRequest.title
             actual.content shouldBe updateRequest.content
             actual.chatLink shouldBe updateRequest.chatLink
-            actual.province!!.id.shouldBe(findProvince!!.id)
+            actual.province!!.id.shouldBe(findProvince[0].id)
         }
 
         test("자신의 글만 수정할 수 있다.") {

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/repository/ProvinceRepository.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/repository/ProvinceRepository.kt
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.Query
 
 interface ProvinceRepository : JpaRepository<Province, Long> {
     @Query("SELECT p FROM Province p JOIN FETCH p.city WHERE p.name = :name")
-    fun findByName(name: String): Province?
+    fun findByName(name: String): List<Province>
 }


### PR DESCRIPTION
## 개요
- close #148 

## 작업사항
-  중복 이름의 province가 저장되기 때문에 findByName의 결과를 List로 받을 수 있도록 변경하였습니다.