### PR TITLE
feat: 152 먹팟 생성, 수정, 상세 QA

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/constants/ValidationMessageConstant.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/constants/ValidationMessageConstant.kt
@@ -1,6 +1,6 @@
 package com.yapp.muckpot.common.constants
 
-const val MAX_APPLY_MIN_INVALID = "참여 인원은 {value}명 이상 가능합니다."
+const val MAX_APPLY_INVALID = "참여 인원은 {value} ~ {value}로 입력해주세요."
 const val TITLE_MAX_INVALID = "제목은 {max}(자)를 넘을 수 없습니다."
 const val CONTENT_MAX_INVALID = "내용은 {max}(자)를 넘을 수 없습니다."
 const val LINK_MAX_INVALID = "링크는 {max}(자)를 넘을 수 없습니다."

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/constants/ValidationMessageConstant.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/constants/ValidationMessageConstant.kt
@@ -1,6 +1,6 @@
 package com.yapp.muckpot.common.constants
 
-const val MAX_APPLY_INVALID = "참여 인원은 {value} ~ {value}로 입력해주세요."
+const val APPLY_RANGE_INVALID = "참여 인원은 {value} ~ {value}로 입력해주세요."
 const val TITLE_MAX_INVALID = "제목은 {max}(자)를 넘을 수 없습니다."
 const val CONTENT_MAX_INVALID = "내용은 {max}(자)를 넘을 수 없습니다."
 const val LINK_MAX_INVALID = "링크는 {max}(자)를 넘을 수 없습니다."

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequest.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequest.kt
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.annotation.JsonFormat
 import com.yapp.muckpot.common.Location
 import com.yapp.muckpot.common.constants.AGE_MAX
 import com.yapp.muckpot.common.constants.AGE_MIN
+import com.yapp.muckpot.common.constants.APPLY_RANGE_INVALID
 import com.yapp.muckpot.common.constants.CHAT_LINK_MAX
 import com.yapp.muckpot.common.constants.CONTENT_MAX
 import com.yapp.muckpot.common.constants.CONTENT_MAX_INVALID
 import com.yapp.muckpot.common.constants.HHmm
 import com.yapp.muckpot.common.constants.LINK_MAX_INVALID
-import com.yapp.muckpot.common.constants.MAX_APPLY_INVALID
 import com.yapp.muckpot.common.constants.NOT_BLANK_COMMON
 import com.yapp.muckpot.common.constants.TITLE_MAX
 import com.yapp.muckpot.common.constants.TITLE_MAX_INVALID
@@ -35,7 +35,7 @@ data class MuckpotCreateRequest(
     @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = HHmm)
     val meetingTime: LocalTime,
     @field:ApiModelProperty(notes = "최대 참여 인원", required = true, example = "5")
-    @field:Range(min = 2, max = 100, message = MAX_APPLY_INVALID)
+    @field:Range(min = 2, max = 100, message = APPLY_RANGE_INVALID)
     val maxApply: Int = 2,
     @field:ApiModelProperty(notes = "최소 나이", required = false, example = "20")
     val minAge: Int? = null,

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequest.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequest.kt
@@ -9,7 +9,7 @@ import com.yapp.muckpot.common.constants.CONTENT_MAX
 import com.yapp.muckpot.common.constants.CONTENT_MAX_INVALID
 import com.yapp.muckpot.common.constants.HHmm
 import com.yapp.muckpot.common.constants.LINK_MAX_INVALID
-import com.yapp.muckpot.common.constants.MAX_APPLY_MIN_INVALID
+import com.yapp.muckpot.common.constants.MAX_APPLY_INVALID
 import com.yapp.muckpot.common.constants.NOT_BLANK_COMMON
 import com.yapp.muckpot.common.constants.TITLE_MAX
 import com.yapp.muckpot.common.constants.TITLE_MAX_INVALID
@@ -20,10 +20,10 @@ import com.yapp.muckpot.domains.user.entity.MuckPotUser
 import io.swagger.annotations.ApiModel
 import io.swagger.annotations.ApiModelProperty
 import org.hibernate.validator.constraints.Length
+import org.hibernate.validator.constraints.Range
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
-import javax.validation.constraints.Min
 import javax.validation.constraints.NotBlank
 
 @ApiModel(value = "먹팟생성 요청")
@@ -35,7 +35,7 @@ data class MuckpotCreateRequest(
     @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = HHmm)
     val meetingTime: LocalTime,
     @field:ApiModelProperty(notes = "최대 참여 인원", required = true, example = "5")
-    @field:Min(2, message = MAX_APPLY_MIN_INVALID)
+    @field:Range(min = 2, max = 100, message = MAX_APPLY_INVALID)
     val maxApply: Int = 2,
     @field:ApiModelProperty(notes = "최소 나이", required = false, example = "20")
     val minAge: Int? = null,

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotDetailResponse.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotDetailResponse.kt
@@ -31,7 +31,8 @@ data class MuckpotDetailResponse(
     val locationDetail: String? = null,
     val views: Int,
     val userAge: Int?,
-    var participants: List<ParticipantReadResponse>
+    var participants: List<ParticipantReadResponse>,
+    val isOutOfDate: Boolean
 ) {
     init {
         if (participants.isNotEmpty()) {
@@ -87,7 +88,8 @@ data class MuckpotDetailResponse(
                 locationDetail = board.locationDetail,
                 views = board.views,
                 userAge = userAge,
-                participants = participants
+                participants = participants,
+                isOutOfDate = board.isOutOfDate()
             )
             if (board.isNotAgeLimit()) {
                 response.changeIsNotAgeLimit()

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotUpdateRequest.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotUpdateRequest.kt
@@ -24,6 +24,7 @@ import io.swagger.annotations.ApiModel
 import io.swagger.annotations.ApiModelProperty
 import org.hibernate.validator.constraints.Length
 import org.hibernate.validator.constraints.Range
+import java.lang.IllegalArgumentException
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -159,6 +160,9 @@ data class MuckpotUpdateRequest(
                     ageLimitFormat.format(this.minAge, this.maxAge)
                 )
             )
+        }
+        if (modifyBody.isEmpty()) {
+            throw IllegalArgumentException("변경된 내용이 없습니다.")
         }
         return modifyBody.toString()
     }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotUpdateRequest.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotUpdateRequest.kt
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.annotation.JsonFormat
 import com.yapp.muckpot.common.Location
 import com.yapp.muckpot.common.constants.AGE_MAX
 import com.yapp.muckpot.common.constants.AGE_MIN
+import com.yapp.muckpot.common.constants.APPLY_RANGE_INVALID
 import com.yapp.muckpot.common.constants.CHAT_LINK_MAX
 import com.yapp.muckpot.common.constants.CONTENT_MAX
 import com.yapp.muckpot.common.constants.CONTENT_MAX_INVALID
 import com.yapp.muckpot.common.constants.HHmm
 import com.yapp.muckpot.common.constants.LINK_MAX_INVALID
-import com.yapp.muckpot.common.constants.MAX_APPLY_INVALID
 import com.yapp.muckpot.common.constants.NOT_BLANK_COMMON
 import com.yapp.muckpot.common.constants.TITLE_MAX
 import com.yapp.muckpot.common.constants.TITLE_MAX_INVALID
@@ -39,7 +39,7 @@ data class MuckpotUpdateRequest(
     @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = HHmm)
     val meetingTime: LocalTime,
     @field:ApiModelProperty(notes = "최대 참여 인원", required = true, example = "5")
-    @field:Range(min = 2, max = 100, message = MAX_APPLY_INVALID)
+    @field:Range(min = 2, max = 100, message = APPLY_RANGE_INVALID)
     val maxApply: Int = 2,
     @field:ApiModelProperty(notes = "최소 나이", required = false, example = "20")
     val minAge: Int? = null,

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotUpdateRequest.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotUpdateRequest.kt
@@ -17,6 +17,7 @@ import com.yapp.muckpot.common.constants.YYYYMMDD
 import com.yapp.muckpot.domains.board.entity.Board
 import com.yapp.muckpot.domains.board.entity.Province
 import com.yapp.muckpot.domains.board.exception.BoardErrorCode
+import com.yapp.muckpot.domains.user.enums.MuckPotStatus
 import com.yapp.muckpot.email.EmailTemplate
 import com.yapp.muckpot.exception.MuckPotException
 import io.swagger.annotations.ApiModel
@@ -95,6 +96,9 @@ data class MuckpotUpdateRequest(
         board.maxApply = this.maxApply
         board.chatLink = this.chatLink
         board.province = province
+        if (board.meetingTime < LocalDateTime.now()) {
+            board.status = MuckPotStatus.DONE
+        }
     }
 
     fun createBoardUpdateMailBody(board: Board): String {

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotUpdateRequest.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotUpdateRequest.kt
@@ -9,7 +9,7 @@ import com.yapp.muckpot.common.constants.CONTENT_MAX
 import com.yapp.muckpot.common.constants.CONTENT_MAX_INVALID
 import com.yapp.muckpot.common.constants.HHmm
 import com.yapp.muckpot.common.constants.LINK_MAX_INVALID
-import com.yapp.muckpot.common.constants.MAX_APPLY_MIN_INVALID
+import com.yapp.muckpot.common.constants.MAX_APPLY_INVALID
 import com.yapp.muckpot.common.constants.NOT_BLANK_COMMON
 import com.yapp.muckpot.common.constants.TITLE_MAX
 import com.yapp.muckpot.common.constants.TITLE_MAX_INVALID
@@ -22,10 +22,10 @@ import com.yapp.muckpot.exception.MuckPotException
 import io.swagger.annotations.ApiModel
 import io.swagger.annotations.ApiModelProperty
 import org.hibernate.validator.constraints.Length
+import org.hibernate.validator.constraints.Range
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
-import javax.validation.constraints.Min
 import javax.validation.constraints.NotBlank
 
 @ApiModel(value = "먹팟수정 요청")
@@ -37,7 +37,7 @@ data class MuckpotUpdateRequest(
     @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = HHmm)
     val meetingTime: LocalTime,
     @field:ApiModelProperty(notes = "최대 참여 인원", required = true, example = "5")
-    @field:Min(2, message = MAX_APPLY_MIN_INVALID)
+    @field:Range(min = 2, max = 100, message = MAX_APPLY_INVALID)
     val maxApply: Int = 2,
     @field:ApiModelProperty(notes = "최소 나이", required = false, example = "20")
     val minAge: Int? = null,

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotUpdateRequest.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotUpdateRequest.kt
@@ -96,7 +96,7 @@ data class MuckpotUpdateRequest(
         board.maxApply = this.maxApply
         board.chatLink = this.chatLink
         board.province = province
-        if (board.meetingTime < LocalDateTime.now()) {
+        if (board.isOutOfDate()) {
             board.status = MuckPotStatus.DONE
         }
     }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/deprecated/MuckpotCreateRequestV1.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/deprecated/MuckpotCreateRequestV1.kt
@@ -9,7 +9,7 @@ import com.yapp.muckpot.common.constants.CONTENT_MAX
 import com.yapp.muckpot.common.constants.CONTENT_MAX_INVALID
 import com.yapp.muckpot.common.constants.HHmm
 import com.yapp.muckpot.common.constants.LINK_MAX_INVALID
-import com.yapp.muckpot.common.constants.MAX_APPLY_MIN_INVALID
+import com.yapp.muckpot.common.constants.MAX_APPLY_INVALID
 import com.yapp.muckpot.common.constants.NOT_BLANK_COMMON
 import com.yapp.muckpot.common.constants.TITLE_MAX
 import com.yapp.muckpot.common.constants.TITLE_MAX_INVALID
@@ -35,7 +35,7 @@ data class MuckpotCreateRequestV1(
     @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = HHmm)
     val meetingTime: LocalTime,
     @field:ApiModelProperty(notes = "최대 참여 인원", required = true, example = "5")
-    @field:Min(2, message = MAX_APPLY_MIN_INVALID)
+    @field:Min(2, message = MAX_APPLY_INVALID)
     val maxApply: Int = 2,
     @field:ApiModelProperty(notes = "최소 나이", required = false, example = "20")
     val minAge: Int? = null,

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/deprecated/MuckpotCreateRequestV1.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/deprecated/MuckpotCreateRequestV1.kt
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.annotation.JsonFormat
 import com.yapp.muckpot.common.Location
 import com.yapp.muckpot.common.constants.AGE_MAX
 import com.yapp.muckpot.common.constants.AGE_MIN
+import com.yapp.muckpot.common.constants.APPLY_RANGE_INVALID
 import com.yapp.muckpot.common.constants.CHAT_LINK_MAX
 import com.yapp.muckpot.common.constants.CONTENT_MAX
 import com.yapp.muckpot.common.constants.CONTENT_MAX_INVALID
 import com.yapp.muckpot.common.constants.HHmm
 import com.yapp.muckpot.common.constants.LINK_MAX_INVALID
-import com.yapp.muckpot.common.constants.MAX_APPLY_INVALID
 import com.yapp.muckpot.common.constants.NOT_BLANK_COMMON
 import com.yapp.muckpot.common.constants.TITLE_MAX
 import com.yapp.muckpot.common.constants.TITLE_MAX_INVALID
@@ -35,7 +35,7 @@ data class MuckpotCreateRequestV1(
     @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = HHmm)
     val meetingTime: LocalTime,
     @field:ApiModelProperty(notes = "최대 참여 인원", required = true, example = "5")
-    @field:Min(2, message = MAX_APPLY_INVALID)
+    @field:Min(2, message = APPLY_RANGE_INVALID)
     val maxApply: Int = 2,
     @field:ApiModelProperty(notes = "최소 나이", required = false, example = "20")
     val minAge: Int? = null,

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/deprecated/MuckpotUpdateRequestV1.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/deprecated/MuckpotUpdateRequestV1.kt
@@ -9,7 +9,7 @@ import com.yapp.muckpot.common.constants.CONTENT_MAX
 import com.yapp.muckpot.common.constants.CONTENT_MAX_INVALID
 import com.yapp.muckpot.common.constants.HHmm
 import com.yapp.muckpot.common.constants.LINK_MAX_INVALID
-import com.yapp.muckpot.common.constants.MAX_APPLY_MIN_INVALID
+import com.yapp.muckpot.common.constants.MAX_APPLY_INVALID
 import com.yapp.muckpot.common.constants.NOT_BLANK_COMMON
 import com.yapp.muckpot.common.constants.TITLE_MAX
 import com.yapp.muckpot.common.constants.TITLE_MAX_INVALID
@@ -37,7 +37,7 @@ data class MuckpotUpdateRequestV1(
     @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = HHmm)
     val meetingTime: LocalTime,
     @field:ApiModelProperty(notes = "최대 참여 인원", required = true, example = "5")
-    @field:Min(2, message = MAX_APPLY_MIN_INVALID)
+    @field:Min(2, message = MAX_APPLY_INVALID)
     val maxApply: Int = 2,
     @field:ApiModelProperty(notes = "최소 나이", required = false, example = "20")
     val minAge: Int? = null,

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/deprecated/MuckpotUpdateRequestV1.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/deprecated/MuckpotUpdateRequestV1.kt
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.annotation.JsonFormat
 import com.yapp.muckpot.common.Location
 import com.yapp.muckpot.common.constants.AGE_MAX
 import com.yapp.muckpot.common.constants.AGE_MIN
+import com.yapp.muckpot.common.constants.APPLY_RANGE_INVALID
 import com.yapp.muckpot.common.constants.CHAT_LINK_MAX
 import com.yapp.muckpot.common.constants.CONTENT_MAX
 import com.yapp.muckpot.common.constants.CONTENT_MAX_INVALID
 import com.yapp.muckpot.common.constants.HHmm
 import com.yapp.muckpot.common.constants.LINK_MAX_INVALID
-import com.yapp.muckpot.common.constants.MAX_APPLY_INVALID
 import com.yapp.muckpot.common.constants.NOT_BLANK_COMMON
 import com.yapp.muckpot.common.constants.TITLE_MAX
 import com.yapp.muckpot.common.constants.TITLE_MAX_INVALID
@@ -37,7 +37,7 @@ data class MuckpotUpdateRequestV1(
     @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = HHmm)
     val meetingTime: LocalTime,
     @field:ApiModelProperty(notes = "최대 참여 인원", required = true, example = "5")
-    @field:Min(2, message = MAX_APPLY_INVALID)
+    @field:Min(2, message = APPLY_RANGE_INVALID)
     val maxApply: Int = 2,
     @field:ApiModelProperty(notes = "최소 나이", required = false, example = "20")
     val minAge: Int? = null,

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequestTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequestTest.kt
@@ -2,6 +2,7 @@ package com.yapp.muckpot.domains.board.controller.dto
 
 import com.yapp.muckpot.common.constants.CHAT_LINK_MAX
 import com.yapp.muckpot.common.constants.CONTENT_MAX
+import com.yapp.muckpot.common.constants.MAX_APPLY_INVALID
 import com.yapp.muckpot.common.constants.NOT_BLANK_COMMON
 import com.yapp.muckpot.common.constants.TITLE_MAX
 import io.kotest.core.spec.style.StringSpec
@@ -110,6 +111,16 @@ class MuckpotCreateRequestTest : StringSpec({
         violations.size shouldBe 1
         for (violation in violations) {
             violation.message shouldBe NOT_BLANK_COMMON
+        }
+    }
+
+    "참여인원은 100명을 넘을 수 없다." {
+        val request = createMuckpotCreateRequest(maxApply = 101)
+
+        val violations: MutableSet<ConstraintViolation<MuckpotCreateRequest>> = validator.validate(request)
+        violations.size shouldBe 1
+        for (violation in violations) {
+            violation.message shouldBe MAX_APPLY_INVALID.format(2, 100)
         }
     }
 })

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequestTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequestTest.kt
@@ -1,8 +1,8 @@
 package com.yapp.muckpot.domains.board.controller.dto
 
+import com.yapp.muckpot.common.constants.APPLY_RANGE_INVALID
 import com.yapp.muckpot.common.constants.CHAT_LINK_MAX
 import com.yapp.muckpot.common.constants.CONTENT_MAX
-import com.yapp.muckpot.common.constants.MAX_APPLY_INVALID
 import com.yapp.muckpot.common.constants.NOT_BLANK_COMMON
 import com.yapp.muckpot.common.constants.TITLE_MAX
 import io.kotest.core.spec.style.StringSpec
@@ -120,7 +120,7 @@ class MuckpotCreateRequestTest : StringSpec({
         val violations: MutableSet<ConstraintViolation<MuckpotCreateRequest>> = validator.validate(request)
         violations.size shouldBe 1
         for (violation in violations) {
-            violation.message shouldBe MAX_APPLY_INVALID.format(2, 100)
+            violation.message shouldBe APPLY_RANGE_INVALID.format(2, 100)
         }
     }
 })

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotDetailResponseTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotDetailResponseTest.kt
@@ -7,6 +7,7 @@ import com.yapp.muckpot.domains.user.controller.dto.UserResponse
 import com.yapp.muckpot.domains.user.enums.JobGroupMain
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
 
 class MuckpotDetailResponseTest : StringSpec({
     "로그인 유저가 참여했다면 가장 첫번째로 정렬된다." {
@@ -54,5 +55,37 @@ class MuckpotDetailResponseTest : StringSpec({
         // then
         response.minAge shouldBe null
         response.maxAge shouldBe null
+    }
+
+    "현재시간 미만은 isOutOfDate=true" {
+        // given
+        val participants = listOf(
+            ParticipantReadResponse(1, 1, "user1", JobGroupMain.DEVELOPMENT)
+        )
+        // when
+        val response = MuckpotDetailResponse.of(
+            Fixture.createBoard(
+                meetingTime = LocalDateTime.now().minusMinutes(10)
+            ),
+            participants
+        )
+        // then
+        response.isOutOfDate shouldBe true
+    }
+
+    "현재시간 이후는 isOutOfDate=false" {
+        // given
+        val participants = listOf(
+            ParticipantReadResponse(1, 1, "user1", JobGroupMain.DEVELOPMENT)
+        )
+        // when
+        val response = MuckpotDetailResponse.of(
+            Fixture.createBoard(
+                meetingTime = LocalDateTime.now().plusMinutes(10)
+            ),
+            participants
+        )
+        // then
+        response.isOutOfDate shouldBe false
     }
 })

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
@@ -286,12 +286,12 @@ class BoardServiceTest @Autowired constructor(
 
         test("자신의 글만 수정할 수 있다.") {
             // given
+            val otherUserId = -1L
             val boardId = boardService.saveBoard(userId, createRequest)!!
-            boardService.changeStatus(userId, boardId, MuckPotStatus.DONE)
             // when & then
             shouldThrow<MuckPotException> {
-                boardService.updateBoardAndSendEmail(userId, boardId, updateRequest)
-            }.errorCode shouldBe BoardErrorCode.DONE_BOARD_NOT_UPDATE
+                boardService.updateBoardAndSendEmail(otherUserId, boardId, updateRequest)
+            }.errorCode shouldBe BoardErrorCode.BOARD_UNAUTHORIZED
         }
 
         test("만료 상태의 먹팟은 수정할 수 없다.") {

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
@@ -287,6 +287,26 @@ class BoardServiceTest @Autowired constructor(
         test("자신의 글만 수정할 수 있다.") {
             // given
             val boardId = boardService.saveBoard(userId, createRequest)!!
+            boardService.changeStatus(userId, boardId, MuckPotStatus.DONE)
+            // when & then
+            shouldThrow<MuckPotException> {
+                boardService.updateBoardAndSendEmail(userId, boardId, updateRequest)
+            }.errorCode shouldBe BoardErrorCode.DONE_BOARD_NOT_UPDATE
+        }
+
+        test("만료 상태의 먹팟은 수정할 수 없다.") {
+            // given
+            val boardId = boardService.saveBoard(userId, createRequest)!!
+            boardService.changeStatus(userId, boardId, MuckPotStatus.DONE)
+            // when & then
+            shouldThrow<MuckPotException> {
+                boardService.updateBoardAndSendEmail(userId, boardId, updateRequest)
+            }.errorCode shouldBe BoardErrorCode.DONE_BOARD_NOT_UPDATE
+        }
+
+        test("현재시간 미만으로 수정시 DONE으로 상태가 변경된다.") {
+            // given
+            val boardId = boardService.saveBoard(userId, createRequest)!!
             val request = MuckpotUpdateRequest(
                 meetingDate = LocalDate.now(),
                 meetingTime = LocalTime.of(0, 0),
@@ -309,26 +329,6 @@ class BoardServiceTest @Autowired constructor(
             val actual = boardRepository.findByIdOrNull(boardId)!!
 
             actual.status shouldBe MuckPotStatus.DONE
-        }
-
-        test("만료 상태의 먹팟은 수정할 수 없다.") {
-            // given
-            val boardId = boardService.saveBoard(userId, createRequest)!!
-            boardService.changeStatus(userId, boardId, MuckPotStatus.DONE)
-            // when & then
-            shouldThrow<MuckPotException> {
-                boardService.updateBoardAndSendEmail(userId, boardId, updateRequest)
-            }.errorCode shouldBe BoardErrorCode.DONE_BOARD_NOT_UPDATE
-        }
-
-        test("현재시간 미만으로 수정시 DONE으로 상태가 변경된다.") {
-            // given
-            val boardId = boardService.saveBoard(userId, createRequest)!!
-            boardService.changeStatus(userId, boardId, MuckPotStatus.DONE)
-            // when & then
-            shouldThrow<MuckPotException> {
-                boardService.updateBoardAndSendEmail(userId, boardId, updateRequest)
-            }.errorCode shouldBe BoardErrorCode.DONE_BOARD_NOT_UPDATE
         }
     }
 

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
@@ -92,7 +92,7 @@ class Board(
         require(maxAge in AGE_MIN..AGE_MAX) { AGE_EXP_MSG }
         require(minAge < maxAge) { "최소나이는 최대나이보다 작아야 합니다." }
         require(maxApply >= MAX_APPLY_MIN) { "최대 인원은 ${MAX_APPLY_MIN}명 이상 가능합니다." }
-        if (meetingTime < LocalDateTime.now()) {
+        if (isOutOfDate()) {
             this.status = DONE
         }
     }
@@ -148,6 +148,10 @@ class Board(
 
     fun isFull(): Boolean {
         return this.currentApply == this.maxApply
+    }
+
+    fun isOutOfDate(): Boolean {
+        return meetingTime < LocalDateTime.now()
     }
 
     private fun validateToday() {

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
@@ -92,7 +92,9 @@ class Board(
         require(maxAge in AGE_MIN..AGE_MAX) { AGE_EXP_MSG }
         require(minAge < maxAge) { "최소나이는 최대나이보다 작아야 합니다." }
         require(maxApply >= MAX_APPLY_MIN) { "최대 인원은 ${MAX_APPLY_MIN}명 이상 가능합니다." }
-        require(meetingTime > LocalDateTime.now()) { "만날 시간은 현재시간 이후에 가능합니다." }
+        if (meetingTime < LocalDateTime.now()) {
+            this.status = DONE
+        }
     }
 
     fun join(userAge: Int) {

--- a/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/entity/BoardTest.kt
+++ b/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/entity/BoardTest.kt
@@ -27,12 +27,10 @@ class BoardTest : FunSpec({
             }.message shouldBe "최대 인원은 ${MAX_APPLY_MIN}명 이상 가능합니다."
         }
 
-        test("만날 시간은 현재시간 이후로만 가능하다.") {
-            shouldThrow<IllegalArgumentException> {
-                Fixture.createBoard(
-                    meetingTime = LocalDateTime.now().minusMinutes(30)
-                )
-            }.message shouldBe "만날 시간은 현재시간 이후에 가능합니다."
+        test("현재시간 미만의 먹팟은 DONE으로 생성된다.") {
+            val board = Fixture.createBoard(meetingTime = LocalDateTime.now().minusMinutes(10))
+
+            board.status shouldBe MuckPotStatus.DONE
         }
 
         test("정원이 초과된 경우 참여할 수 없다.") {


### PR DESCRIPTION
## 개요
- close #152 

## 작업사항
- 먹팟 생성
  - 현재시간 미만의 먹팟은 모집 종료 상태로 생성
- 먹팟 수정
  - 현재시간 미만의 먹팟은 모집 종료 상태로 변경
  - 변경된 내용이 없을 때 수정할 수 없도록 유효성 추가
- 생성 & 수정
  - 최대참여인원 2 ~ 100 제한
- 먹팟 상세
  - 날짜 지난 경우 모집 마감 버튼 비활성화를 위해 isOutOfDate 필드 추가
