### PR TITLE
bug: 159 로그아웃 쿠키삭제, 비로그인만 접속가능한 API 추가

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/utils/CookieUtil.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/utils/CookieUtil.kt
@@ -1,5 +1,7 @@
 package com.yapp.muckpot.common.utils
 
+import com.yapp.muckpot.common.constants.ACCESS_TOKEN_KEY
+import com.yapp.muckpot.common.constants.REFRESH_TOKEN_KEY
 import com.yapp.muckpot.domains.user.exception.UserErrorCode
 import com.yapp.muckpot.exception.MuckPotException
 import org.springframework.web.context.request.RequestContextHolder
@@ -51,5 +53,10 @@ object CookieUtil {
             }
         }
         currentResponse.addCookie(cookie)
+    }
+
+    fun allTokenClear() {
+        addHttpOnlyCookie(ACCESS_TOKEN_KEY, "", 0)
+        addHttpOnlyCookie(REFRESH_TOKEN_KEY, "", 0)
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/service/JwtService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/service/JwtService.kt
@@ -64,6 +64,8 @@ class JwtService(
      * 현재 HttpServletRequest의 AccessToken을 찾아 유저 정보 반환
      *
      * @return UserResponse? 유저 정보가 없는 경우 null 반환
+     * @return UserResponse tokenExpired=false 로그인 유저
+     * @return UserResponse tokenExpired=true 토큰이 만료된 유저 (비정상), 별도 처리 필요
      */
     fun getCurrentUserClaim(): UserResponse? {
         return try {

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/filter/JwtAuthorizationFilter.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/filter/JwtAuthorizationFilter.kt
@@ -1,5 +1,7 @@
 package com.yapp.muckpot.filter
 
+import com.yapp.muckpot.common.constants.EMAIL_REQUEST_URL
+import com.yapp.muckpot.common.constants.EMAIL_VERIFY_URL
 import com.yapp.muckpot.common.constants.LOGIN_URL
 import com.yapp.muckpot.common.constants.REISSUE_JWT_URL
 import com.yapp.muckpot.common.constants.SIGN_UP_URL
@@ -23,7 +25,7 @@ class JwtAuthorizationFilter(private val jwtService: JwtService) : OncePerReques
         filterChain: FilterChain
     ) {
         jwtService.getCurrentUserClaim()?.let { userResponse ->
-            if (ALREADY_LOGIN_REJECT_URLS.contains(request.requestURI.toString())) {
+            if (ONLY_NON_LOGIN_USER_URLS.contains(request.requestURI.toString())) {
                 if (userResponse.tokenExpired) {
                     filterChain.doFilter(request, response)
                     return
@@ -46,15 +48,18 @@ class JwtAuthorizationFilter(private val jwtService: JwtService) : OncePerReques
         }
         filterChain.doFilter(request, response)
     }
+
     private fun needAccessTokenExpiredCheck(requestMethod: String, requestUri: String): Boolean {
         return (requestMethod != HttpMethod.GET.toString() && !TOKEN_EXPIRED_NOT_CHECK_URLS.contains(requestUri))
     }
 
     companion object {
         private val LOGIN_USER_AUTHORITIES = listOf(SimpleGrantedAuthority("ROLE_USER"))
-        private val ALREADY_LOGIN_REJECT_URLS = listOf(
+        private val ONLY_NON_LOGIN_USER_URLS = listOf(
             LOGIN_URL,
-            SIGN_UP_URL
+            SIGN_UP_URL,
+            EMAIL_REQUEST_URL,
+            EMAIL_VERIFY_URL
         )
         private val TOKEN_EXPIRED_NOT_CHECK_URLS = listOf(
             REISSUE_JWT_URL

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/filter/JwtLogoutHandler.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/filter/JwtLogoutHandler.kt
@@ -1,5 +1,6 @@
 package com.yapp.muckpot.filter
 
+import com.yapp.muckpot.common.utils.CookieUtil
 import com.yapp.muckpot.common.utils.ResponseWriter
 import com.yapp.muckpot.domains.user.service.JwtService
 import org.springframework.http.HttpStatus
@@ -15,5 +16,6 @@ class JwtLogoutHandler(
         if (!jwtService.allTokenClear()) {
             ResponseWriter.writeResponse(response, HttpStatus.BAD_REQUEST.value(), "로그아웃 실패.")
         }
+        CookieUtil.allTokenClear()
     }
 }


### PR DESCRIPTION
## 개요
- close #159 

## 작업사항
- 로그아웃 -> accessToken 블랙리스트 등록 -> 블랙리스트 ttl 만료 -> 쿠키가 남아있음 -> 회원가입 과정에서 토큰 만료를 검사하고 있음
  - 로그아웃시 쿠키삭제하도록 로직추가
- 비로그인 유저만 사용가능한 API 추가
  - 이메일 인증 요청, 이메일 인증 API는 로그인 유저는 접근할 수 없음. filter에 추가 함.