### PR TITLE
refactor: 161 조회 정렬순서 변경

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/constants/ValidationMessageConstant.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/constants/ValidationMessageConstant.kt
@@ -1,6 +1,6 @@
 package com.yapp.muckpot.common.constants
 
-const val APPLY_RANGE_INVALID = "참여 인원은 {value} ~ {value}로 입력해주세요."
+const val APPLY_RANGE_INVALID = "참여 인원은 {min} ~ {max}로 입력해주세요."
 const val TITLE_MAX_INVALID = "제목은 {max}(자)를 넘을 수 없습니다."
 const val CONTENT_MAX_INVALID = "내용은 {max}(자)를 넘을 수 없습니다."
 const val LINK_MAX_INVALID = "링크는 {max}(자)를 넘을 수 없습니다."

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
@@ -76,12 +76,13 @@ class BoardService(
                 board.visit()
             }
             val userAge: Int? = loginUserInfo?.let { userRepository.findByIdOrNull(it.userId)?.getAge() }
+            val prevAndNextId = boardQuerydslRepository.findPrevAndNextId(boardId, request.cityId, request.provinceId)
 
             return MuckpotDetailResponse.of(
                 board = board,
                 participants = participantQuerydslRepository.findByBoardIds(listOf(boardId)),
-                prevId = boardQuerydslRepository.findPrevId(boardId, request.cityId, request.provinceId),
-                nextId = boardQuerydslRepository.findNextId(boardId, request.cityId, request.provinceId),
+                prevId = prevAndNextId.first,
+                nextId = prevAndNextId.second,
                 userAge = userAge
             ).apply {
                 sortParticipantsByLoginUser(loginUserInfo)

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequestTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequestTest.kt
@@ -1,6 +1,5 @@
 package com.yapp.muckpot.domains.board.controller.dto
 
-import com.yapp.muckpot.common.constants.APPLY_RANGE_INVALID
 import com.yapp.muckpot.common.constants.CHAT_LINK_MAX
 import com.yapp.muckpot.common.constants.CONTENT_MAX
 import com.yapp.muckpot.common.constants.NOT_BLANK_COMMON
@@ -120,7 +119,7 @@ class MuckpotCreateRequestTest : StringSpec({
         val violations: MutableSet<ConstraintViolation<MuckpotCreateRequest>> = validator.validate(request)
         violations.size shouldBe 1
         for (violation in violations) {
-            violation.message shouldBe APPLY_RANGE_INVALID.format(2, 100)
+            violation.message shouldBe "참여 인원은 2 ~ 100로 입력해주세요."
         }
     }
 })

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceMockTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceMockTest.kt
@@ -104,8 +104,7 @@ class BoardServiceMockTest @Autowired constructor(
             // given
             every { boardRepository.findByIdOrNull(any()) } returns board
             every { participantQuerydslRepository.findByBoardIds(any()) } returns participantResponses
-            every { boardQuerydslRepository.findPrevId(any()) } returns null
-            every { boardQuerydslRepository.findNextId(any()) } returns null
+            every { boardQuerydslRepository.findPrevAndNextId(any()) } returns Pair(null, null)
         }
 
         test("먹팟 상세조회 성공") {

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/repository/BoardQuerydslRepository.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/repository/BoardQuerydslRepository.kt
@@ -20,31 +20,23 @@ import java.time.LocalDateTime
 class BoardQuerydslRepository(
     private val queryFactory: JPAQueryFactory
 ) {
-    fun findAllWithPagination(lastId: Long?, countPerScroll: Long): List<Board> {
-        return queryFactory.from(board)
-            .select(board)
-            .where(
-                lessThanLastId(lastId)
-            )
-            .orderBy(board.createdAt.desc())
-            .limit(countPerScroll)
+    fun findPrevAndNextId(boardId: Long, cityId: Long? = null, provinceId: Long? = null): Pair<Long?, Long?> {
+        val idList = queryFactory.from(board)
+            .innerJoin(board.province, province)
+            .select(board.id)
+            .where(cityIdEqBoard(cityId), provinceIdEqBoard(provinceId))
+            .orderBy(*boardCommonOrderByList.toTypedArray())
             .fetch()
-    }
-
-    fun findPrevId(boardId: Long, cityId: Long? = null, provinceId: Long? = null): Long? {
-        return queryFactory.from(board)
-            .innerJoin(board.province, province)
-            .select(board.id.min())
-            .where(board.id.gt(boardId), cityIdEqBoard(cityId), provinceIdEqBoard(provinceId))
-            .fetchOne()
-    }
-
-    fun findNextId(boardId: Long, cityId: Long? = null, provinceId: Long? = null): Long? {
-        return queryFactory.from(board)
-            .innerJoin(board.province, province)
-            .select(board.id.max())
-            .where(board.id.lt(boardId), cityIdEqBoard(cityId), provinceIdEqBoard(provinceId))
-            .fetchOne()
+        var prevId: Long? = null
+        var nextId: Long? = null
+        val boardIdIndex = idList.indexOf(boardId)
+        if (boardIdIndex > 0) {
+            prevId = idList[boardIdIndex - 1]
+        }
+        if (boardIdIndex + 1 < idList.size) {
+            nextId = idList[boardIdIndex + 1]
+        }
+        return prevId to nextId
     }
 
     @Transactional
@@ -100,7 +92,7 @@ class BoardQuerydslRepository(
             .select(board)
             .innerJoin(board.province, province)
             .where(lessThanLastId(lastId), cityIdEqBoard(cityId), provinceIdEqBoard(provinceId))
-            .orderBy(board.createdAt.desc())
+            .orderBy(*boardCommonOrderByList.toTypedArray())
             .limit(countPerScroll)
             .fetch()
     }
@@ -112,5 +104,9 @@ class BoardQuerydslRepository(
             .leftJoin(province.city, city).fetchJoin()
             .where(board.id.eq(boardId))
             .fetchOne()
+    }
+
+    companion object {
+        private val boardCommonOrderByList = listOf(board.status.desc(), board.createdAt.desc())
     }
 }

--- a/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/repository/BoardQuerydslRepositoryTest.kt
+++ b/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/repository/BoardQuerydslRepositoryTest.kt
@@ -36,7 +36,7 @@ class BoardQuerydslRepositoryTest(
         province = provinceRepository.save(Fixture.createProvince(city = city))
         boards = listOf(
             Fixture.createBoard(title = "board1", user = user, province = province).apply { createdAt = LocalDateTime.now() },
-            Fixture.createBoard(title = "board2", user = user, province = province).apply { createdAt = LocalDateTime.now().plusDays(1) },
+            Fixture.createBoard(title = "board2", user = user, province = province, status = MuckPotStatus.DONE).apply { createdAt = LocalDateTime.now().plusDays(1) },
             Fixture.createBoard(title = "board3", user = user, province = province).apply { createdAt = LocalDateTime.now().plusDays(2) }
         )
 
@@ -54,40 +54,40 @@ class BoardQuerydslRepositoryTest(
     "countPerScroll이 2인 경우" {
         val countPerScroll = 2
         // when
-        val result = boardQuerydslRepository.findAllWithPagination(null, countPerScroll.toLong())
+        val result = boardQuerydslRepository.findAllWithPaginationAndRegion(null, countPerScroll.toLong(), null, null)
         // then
         result shouldHaveSize countPerScroll
     }
 
-    "생성일자 기준 내림차순 정렬" {
+    "진행중 먹팟부터 생성일자 기준 내림차순 정렬" {
         // when
-        val result = boardQuerydslRepository.findAllWithPagination(null, 3)
+        val result = boardQuerydslRepository.findAllWithPaginationAndRegion(null, 3, null, null)
         // then
         result[0].id shouldBe boards[2].id
-        result[1].id shouldBe boards[1].id
-        result[2].id shouldBe boards[0].id
+        result[1].id shouldBe boards[0].id
+        result[2].id shouldBe boards[1].id
     }
 
-    "이전 아이디는 현재 게시글 이후에 등록된 첫번째 글이다." {
+    "이전 아이디는 진행중 먹팟부터 생성일자 기준 내림차순 정렬 후, 한칸 높은 순위(직후 생성 된)의 번호이다." {
         // when
-        val todayPrev = boardQuerydslRepository.findPrevId(boards[0].id!!)
-        val tomorrowPrev = boardQuerydslRepository.findPrevId(boards[1].id!!)
-        val twoDaysLaterPrev = boardQuerydslRepository.findPrevId(boards[2].id!!)
+        val todayPrev = boardQuerydslRepository.findPrevAndNextId(boards[0].id!!, null, null).first
+        val tomorrowPrev = boardQuerydslRepository.findPrevAndNextId(boards[1].id!!, null, null).first
+        val twoDaysLaterPrev = boardQuerydslRepository.findPrevAndNextId(boards[2].id!!, null, null).first
         // then
-        todayPrev shouldBe boards[1].id
-        tomorrowPrev shouldBe boards[2].id
+        todayPrev shouldBe boards[2].id
+        tomorrowPrev shouldBe boards[0].id
         twoDaysLaterPrev shouldBe null
     }
 
-    "다음 아이디는 현재 게시글 이전에 등록된 마지막 글이다." {
+    "이전 아이디는 진행중 먹팟부터 생성일자 기준 내림차순 정렬 후, 한칸 낮은 순위(먼저 생성 된)의 번호이다." {
         // when
-        val todayNext = boardQuerydslRepository.findNextId(boards[0].id!!)
-        val tomorrowNext = boardQuerydslRepository.findNextId(boards[1].id!!)
-        val twoDaysLaterNext = boardQuerydslRepository.findNextId(boards[2].id!!)
+        val todayNext = boardQuerydslRepository.findPrevAndNextId(boards[0].id!!, null, null).second
+        val tomorrowNext = boardQuerydslRepository.findPrevAndNextId(boards[1].id!!, null, null).second
+        val twoDaysLaterNext = boardQuerydslRepository.findPrevAndNextId(boards[2].id!!, null, null).second
         // then
-        todayNext shouldBe null
-        tomorrowNext shouldBe boards[0].id
-        twoDaysLaterNext shouldBe boards[1].id
+        todayNext shouldBe boards[1].id
+        tomorrowNext shouldBe null
+        twoDaysLaterNext shouldBe boards[0].id
     }
 
     "현재시간 미만의 먹팟 상태 업데이트" {
@@ -114,6 +114,12 @@ class BoardQuerydslRepositoryTest(
 
         actual.province?.name shouldBe province.name
         actual.province?.city?.name shouldBe city.name
+    }
+
+    "DONE 상태의 먹팟을 나중에 조회한다." {
+        val actual = boardQuerydslRepository.findAllWithPaginationAndRegion(null, 10, null, null)
+
+        actual[2].status shouldBe MuckPotStatus.DONE
     }
 }) {
     override fun extensions() = listOf(SpringExtension)


### PR DESCRIPTION
## 개요
- close #161 

## 작업사항
- 조회 정렬순서 변경

## 변경로직
- 먹팟 전체조회 정렬기준 변경
  - 모집중 -> 모집마감 순서로 조회
- 먹팟 상세 이전, 이후 아이디 조회로직도 정렬조건 동일하게 맞춤
  - 기존 prevId, nextId 조회 쿼리 삭제 후, 정렬조건 맞춰서 이전, 이후 아이디를 한번에 찾는 findPrevAndNextId 쿼리 추가하였습니다. 
    - 이부분.. lag나 lead를 써서 풀고싶었는데.. querydsl에서 못쓴다그래서.. 좀 무식하게 풀어놨습니다.. 혹시 더 나은 방안 제안주시면 고쳐볼게요 !